### PR TITLE
Fixed various inaccuracies regarding player interaction

### DIFF
--- a/src/player/player_hit.rs
+++ b/src/player/player_hit.rs
@@ -330,7 +330,6 @@ impl Player {
             state.control_flags.set_interactions_disabled(true);
             state.textscript_vm.executor_player = id;
             state.textscript_vm.start_script(npc.event_num);
-            self.cond.set_interacted(false);
             self.vel_x = 0;
             self.question = false;
         }

--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -1537,6 +1537,7 @@ impl GameScene {
 
             if self.player1.controller.trigger_inventory() {
                 state.textscript_vm.set_mode(ScriptMode::Inventory);
+                self.player1.cond.set_interacted(false);
             }
         }
 

--- a/src/text_script.rs
+++ b/src/text_script.rs
@@ -902,6 +902,8 @@ impl TextScriptVM {
                         if let Some(direction) = Direction::from_int_facing(new_direction) {
                             match direction {
                                 Direction::Left => {
+                                    game_scene.player1.direction = Left;
+                                    game_scene.player2.direction = Left;
                                     game_scene.player1.vel_x = 0x200;
                                     game_scene.player2.vel_x = 0x200;
                                 }
@@ -910,6 +912,8 @@ impl TextScriptVM {
                                     game_scene.player2.vel_y = -0x200;
                                 }
                                 Direction::Right => {
+                                    game_scene.player1.direction = Right;
+                                    game_scene.player2.direction = Right;
                                     game_scene.player1.vel_x = -0x200;
                                     game_scene.player2.vel_x = -0x200;
                                 }
@@ -919,7 +923,7 @@ impl TextScriptVM {
                                 }
                                 Direction::FacingPlayer => {
                                     for npc in game_scene.npc_list.iter_alive() {
-                                        if npc.event_num == event_num {
+                                        if npc.event_num == new_direction as u16{
                                             if game_scene.player1.x >= npc.x {
                                                 game_scene.player1.direction = Left;
                                                 game_scene.player1.vel_x = 0x200;
@@ -1275,8 +1279,8 @@ impl TextScriptVM {
                         let pos_x = read_cur_varint(&mut cursor)? as i32 * block_size;
                         let pos_y = read_cur_varint(&mut cursor)? as i32 * block_size;
 
-                        new_scene.player1.cond.set_interacted(false);
-                        new_scene.player2.cond.set_interacted(false);
+                        game_scene.player1.cond.set_interacted(false);
+                        game_scene.player2.cond.set_interacted(false);
 
                         for player in [&mut game_scene.player1, &mut game_scene.player2].iter_mut() {
                             player.vel_x = 0;

--- a/src/text_script.rs
+++ b/src/text_script.rs
@@ -30,6 +30,7 @@ use crate::scene::title_scene::TitleScene;
 use crate::shared_game_state::SharedGameState;
 use crate::str;
 use crate::weapon::WeaponType;
+use crate::common::Direction::{Left, Right};
 
 /// Engine's text script VM operation codes.
 #[derive(EnumString, Debug, FromPrimitive, PartialEq)]
@@ -879,8 +880,9 @@ impl TextScriptVM {
                             game_scene.player1.direction = direction;
                             game_scene.player2.direction = direction;
                         }
-                        game_scene.player1.cond.set_interacted(false);
-                        game_scene.player2.cond.set_interacted(false);
+                        game_scene.player1.cond.set_interacted(new_direction == 3);
+                        game_scene.player2.cond.set_interacted(new_direction == 3);
+
 
                         game_scene.player1.vel_x = 0;
                         game_scene.player2.vel_x = 0;
@@ -914,11 +916,28 @@ impl TextScriptVM {
                                 Direction::Bottom => {
                                     game_scene.player1.vel_y = 0x200;
                                     game_scene.player2.vel_y = 0x200;
-                                    game_scene.player1.cond.set_interacted(true);
-                                    game_scene.player2.cond.set_interacted(true);
                                 }
                                 Direction::FacingPlayer => {
-                                    // todo npc direction dependent bump
+                                    for npc in game_scene.npc_list.iter_alive() {
+                                        if npc.event_num == event_num {
+                                            if game_scene.player1.x >= npc.x {
+                                                game_scene.player1.direction = Left;
+                                                game_scene.player1.vel_x = 0x200;
+                                            }else{
+                                                game_scene.player1.direction = Right;
+                                                game_scene.player1.vel_x = -0x200;
+                                            }
+
+                                            if game_scene.player2.x >= npc.x {
+                                                game_scene.player2.direction = Left;
+                                                game_scene.player2.vel_x = 0x200;
+                                            }else{
+                                                game_scene.player2.direction = Right;
+                                                game_scene.player2.vel_x = -0x200;
+                                            }
+                                            break;
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/text_script.rs
+++ b/src/text_script.rs
@@ -914,6 +914,8 @@ impl TextScriptVM {
                                 Direction::Bottom => {
                                     game_scene.player1.vel_y = 0x200;
                                     game_scene.player2.vel_y = 0x200;
+                                    game_scene.player1.cond.set_interacted(true);
+                                    game_scene.player2.cond.set_interacted(true);
                                 }
                                 Direction::FacingPlayer => {
                                     // todo npc direction dependent bump
@@ -1253,6 +1255,9 @@ impl TextScriptVM {
 
                         let pos_x = read_cur_varint(&mut cursor)? as i32 * block_size;
                         let pos_y = read_cur_varint(&mut cursor)? as i32 * block_size;
+
+                        new_scene.player1.cond.set_interacted(false);
+                        new_scene.player2.cond.set_interacted(false);
 
                         for player in [&mut game_scene.player1, &mut game_scene.player2].iter_mut() {
                             player.vel_x = 0;

--- a/src/text_script.rs
+++ b/src/text_script.rs
@@ -879,6 +879,8 @@ impl TextScriptVM {
                             game_scene.player1.direction = direction;
                             game_scene.player2.direction = direction;
                         }
+                        game_scene.player1.cond.set_interacted(false);
+                        game_scene.player2.cond.set_interacted(false);
 
                         game_scene.player1.vel_x = 0;
                         game_scene.player2.vel_x = 0;
@@ -890,6 +892,10 @@ impl TextScriptVM {
 
                         game_scene.player1.vel_y = -0x200;
                         game_scene.player2.vel_y = -0x200;
+
+                        // Reset interaction condition, needed for places like talking to Toroko in shack
+                        game_scene.player1.cond.set_interacted(false);
+                        game_scene.player2.cond.set_interacted(false);
 
                         if let Some(direction) = Direction::from_int_facing(new_direction) {
                             match direction {
@@ -1221,6 +1227,9 @@ impl TextScriptVM {
                         new_scene.player2.vel_y = 0;
                         new_scene.player2.x = pos_x;
                         new_scene.player2.y = pos_y;
+                        // Reset player interaction flag upon TRA
+                        new_scene.player1.cond.set_interacted(false);
+                        new_scene.player2.cond.set_interacted(false);
                         new_scene.frame.wait = game_scene.frame.wait;
 
                         let skip = state.textscript_vm.flags.cutscene_skip();


### PR DESCRIPTION
Fixed inaccuracies include:
1. Upon interacting with an NPC, the interaction flag is no longer immediately reset
2. Upon <TRA, the interaction flag is reset
3. Upon <MYB, the interaction flag is reset (Otherwise upon talking to toroko it would fling the player, but then they would stay in the interaction pose
4. Upon <MYD, interation flag is reset
5. Upon closing of the inventory, interaction flag is reset (Todo: Maybe in vanilla its upon opening? Didnt check)