### PR TITLE
small start menu fixes

### DIFF
--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -66,14 +66,13 @@ impl SettingsMenu {
             "Game timing:".to_owned(),
             if state.settings.timing_mode == TimingMode::_50Hz { 0 } else { 1 },
             vec!["50tps (freeware)".to_owned(), "60tps (CS+)".to_owned()],
-            vec!["".to_owned(),"".to_owned()],
         ));
 
         self.main.push_entry(MenuEntry::Active(DISCORD_LINK.to_owned()));
 
         self.main.push_entry(MenuEntry::Active("< Back".to_owned()));
 
-        self.sound.push_entry(MenuEntry::Options(
+        self.sound.push_entry(MenuEntry::DescriptiveOptions(
             "BGM Interpolation:".to_owned(),
             state.settings.organya_interpolation as usize,
             vec![
@@ -86,8 +85,8 @@ impl SettingsMenu {
             vec![
                 "(Fastest, lowest quality)".to_owned(),
                 "(Fast, similar to freeware on Vista+)".to_owned(),
-                "(Cosine interp)".to_owned(),
-                "(Cubic interp)".to_owned(),
+                "(Cosine interpolation)".to_owned(),
+                "(Cubic interpolation)".to_owned(),
                 "(Slowest, similar to freeware on XP)".to_owned()
             ],
         ));
@@ -132,7 +131,7 @@ impl SettingsMenu {
                     self.current = CurrentMenu::SoundMenu;
                 }
                 MenuSelectionResult::Selected(2, toggle) => {
-                    if let MenuEntry::Options(_, value, _, _) = toggle {
+                    if let MenuEntry::Options(_, value, _) = toggle {
                         match state.settings.timing_mode {
                             TimingMode::_50Hz => {
                                 state.settings.timing_mode = TimingMode::_60Hz;
@@ -213,7 +212,7 @@ impl SettingsMenu {
             },
             CurrentMenu::SoundMenu => match self.sound.tick(controller, state) {
                 MenuSelectionResult::Selected(0, toggle) => {
-                    if let MenuEntry::Options(_, value, _, _) = toggle {
+                    if let MenuEntry::DescriptiveOptions(_, value, _, _) = toggle {
                         let (new_mode, new_value) = match *value {
                             0 => (InterpolationMode::Linear, 1),
                             1 => (InterpolationMode::Cosine, 2),

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -35,7 +35,7 @@ impl SettingsMenu {
 
     pub fn init(&mut self, state: &mut SharedGameState, ctx: &mut Context) -> GameResult {
         self.graphics.push_entry(MenuEntry::Toggle("Lighting effects:".to_string(), state.settings.shader_effects));
-        self.graphics.push_entry(MenuEntry::Toggle("Player's weapon light cone:".to_string(), state.settings.light_cone));
+        self.graphics.push_entry(MenuEntry::Toggle("Weapon light cone:".to_string(), state.settings.light_cone));
         self.graphics
             .push_entry(MenuEntry::Toggle("Motion interpolation:".to_string(), state.settings.motion_interpolation));
         self.graphics.push_entry(MenuEntry::Toggle("Subpixel scrolling:".to_string(), state.settings.subpixel_coords));
@@ -66,24 +66,32 @@ impl SettingsMenu {
             "Game timing:".to_owned(),
             if state.settings.timing_mode == TimingMode::_50Hz { 0 } else { 1 },
             vec!["50tps (freeware)".to_owned(), "60tps (CS+)".to_owned()],
+            vec!["".to_owned(),"".to_owned()],
         ));
 
         self.main.push_entry(MenuEntry::Active(DISCORD_LINK.to_owned()));
 
         self.main.push_entry(MenuEntry::Active("< Back".to_owned()));
 
-        self.sound.push_entry(MenuEntry::DisabledWhite("BGM Interpolation:".to_owned()));
         self.sound.push_entry(MenuEntry::Options(
-            "".to_owned(),
+            "BGM Interpolation:".to_owned(),
             state.settings.organya_interpolation as usize,
             vec![
-                "Nearest (fastest, lowest quality)".to_owned(),
-                "Linear (fast, similar to freeware on Vista+)".to_owned(),
+                "Nearest".to_owned(),
+                "Linear".to_owned(),
                 "Cosine".to_owned(),
                 "Cubic".to_owned(),
-                "Polyphase (slowest, similar to freeware on XP)".to_owned()
+                "Polyphase".to_owned()
+            ],
+            vec![
+                "(Fastest, lowest quality)".to_owned(),
+                "(Fast, similar to freeware on Vista+)".to_owned(),
+                "(Cosine interp)".to_owned(),
+                "(Cubic interp)".to_owned(),
+                "(Slowest, similar to freeware on XP)".to_owned()
             ],
         ));
+        self.sound.push_entry(MenuEntry::DisabledWhite("".to_owned()));
         self.sound.push_entry(MenuEntry::Disabled(format!("Soundtrack: {}", state.settings.soundtrack)));
         self.sound.push_entry(MenuEntry::Active("< Back".to_owned()));
 
@@ -124,7 +132,7 @@ impl SettingsMenu {
                     self.current = CurrentMenu::SoundMenu;
                 }
                 MenuSelectionResult::Selected(2, toggle) => {
-                    if let MenuEntry::Options(_, value, _) = toggle {
+                    if let MenuEntry::Options(_, value, _, _) = toggle {
                         match state.settings.timing_mode {
                             TimingMode::_50Hz => {
                                 state.settings.timing_mode = TimingMode::_60Hz;
@@ -204,8 +212,8 @@ impl SettingsMenu {
                 _ => (),
             },
             CurrentMenu::SoundMenu => match self.sound.tick(controller, state) {
-                MenuSelectionResult::Selected(1, toggle) => {
-                    if let MenuEntry::Options(_, value, _) = toggle {
+                MenuSelectionResult::Selected(0, toggle) => {
+                    if let MenuEntry::Options(_, value, _, _) = toggle {
                         let (new_mode, new_value) = match *value {
                             0 => (InterpolationMode::Linear, 1),
                             1 => (InterpolationMode::Cosine, 2),


### PR DESCRIPTION
- consistent 14/7 pixel spacing between option and selected value
- fixed small bug in audio menu where cursor would select the first entry, despite being un-selectable
- gave **`MenuEntry:Options`** an additional **`Vec<String>`** for hopefully better descriptions
- removed _"Player's"_ from _"Player's Weapon Light Cone"_ over redundancy and so it'd fit
![doukutsu-rs_uG8WYccuse](https://user-images.githubusercontent.com/53099651/149672621-3e74d4c7-c7f1-4ec0-94a0-99a4487e2600.gif)