### PR TITLE
decorative border fix + spacing

### DIFF
--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -1449,7 +1449,7 @@ impl EngineConstants {
                 menu_right_top: Rect { left: 236, top: 0, right: 244, bottom: 8 },
                 menu_left_bottom: Rect { left: 0, top: 16, right: 8, bottom: 24 },
                 menu_right_bottom: Rect { left: 236, top: 16, right: 244, bottom: 24 },
-                menu_top: Rect { left: 8, top: 0, right: 236, bottom: 8 },
+                menu_top: Rect { left: 8, top: 0, right: 232, bottom: 8 },
                 menu_middle: Rect { left: 8, top: 8, right: 236, bottom: 16 },
                 menu_bottom: Rect { left: 8, top: 16, right: 236, bottom: 24 },
                 menu_left: Rect { left: 0, top: 8, right: 8, bottom: 16 },

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -26,14 +26,14 @@ impl MenuEntry {
     pub fn height(&self) -> f64 {
         match self {
             MenuEntry::Hidden => 0.0,
-            MenuEntry::Active(_) => 14.0,
-            MenuEntry::DisabledWhite(_) => 14.0,
-            MenuEntry::Disabled(_) => 14.0,
-            MenuEntry::Toggle(_, _) => 14.0,
-            MenuEntry::Options(_, _, _) => 14.0,
-            MenuEntry::DescriptiveOptions(_, _, _, _) => 14.0,
-            MenuEntry::SaveData(_) => 30.0,
-            MenuEntry::NewSave => 30.0,
+            MenuEntry::Active(_) => 16.0,
+            MenuEntry::DisabledWhite(_) => 16.0,
+            MenuEntry::Disabled(_) => 16.0,
+            MenuEntry::Toggle(_, _) => 16.0,
+            MenuEntry::Options(_, _, _) => 16.0,
+            MenuEntry::DescriptiveOptions(_, _, _, _) => 16.0,
+            MenuEntry::SaveData(_) => 32.0,
+            MenuEntry::NewSave => 32.0,
         }
     }
 
@@ -96,13 +96,13 @@ impl Menu {
     }
 
     pub fn update_height(&mut self) {
-        let mut height = 6.0;
+        let mut height = 8.0;
 
         for entry in &self.entries {
             height += entry.height();
         }
 
-        self.height = height.max(6.0) as u16;
+        self.height = height.max(8.0) as u16;
     }
 
     pub fn draw(&self, state: &mut SharedGameState, ctx: &mut Context) -> GameResult {

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -26,7 +26,7 @@ static DISCORD_LINK: &str = "https://discord.gg/fbRsNNB";
 
 impl SettingsMenu {
     pub fn new() -> SettingsMenu {
-        let main = Menu::new(0, 0, 200, 0);
+        let main = Menu::new(0, 0, 220, 0);
         let graphics = Menu::new(0, 0, 180, 0);
         let sound = Menu::new(0, 0, 260, 0);
 


### PR DESCRIPTION
all menus now correctly display the border, but i have spaced them a little further apart to do so

https://cdn.discordapp.com/attachments/745322954660905103/934111819952451584/doukutsu-rs_d7U4pIu0nS.gif