### PR TITLE
add CS+ game difficulties

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,11 @@
 use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use lazy_static::lazy_static;
 use num_traits::{abs, Num};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeTupleStruct;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::bitfield;
 use crate::texture_set::G_MAG;
@@ -390,6 +391,11 @@ pub fn interpolate_fix9_scale(old_val: i32, val: i32, frame_delta: f64) -> f32 {
         let mag = G_MAG as f32;
         (interpolated * mag / 512.0).floor() / mag
     }
+}
+
+pub fn get_timestamp() -> u64 {
+    let now = SystemTime::now();
+    now.duration_since(UNIX_EPOCH).unwrap().as_secs() as u64
 }
 
 /// A RGBA color in the `sRGB` color space represented as `f32`'s in the range `[0.0-1.0]`

--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Cursor, Read};
 
-use byteorder::{LE, ReadBytesExt};
+use byteorder::{ReadBytesExt, LE};
 use case_insensitive_hashmap::CaseInsensitiveHashMap;
 use xmltree::Element;
 
@@ -304,6 +304,7 @@ pub struct EngineConstants {
     pub credit_illustration_paths: Vec<String>,
     pub animated_face_table: Vec<AnimatedFace>,
     pub string_table: HashMap<String, String>,
+    pub missile_flags: Vec<u16>,
 }
 
 impl Clone for EngineConstants {
@@ -333,6 +334,7 @@ impl Clone for EngineConstants {
             credit_illustration_paths: self.credit_illustration_paths.clone(),
             animated_face_table: self.animated_face_table.clone(),
             string_table: self.string_table.clone(),
+            missile_flags: self.missile_flags.clone(),
         }
     }
 }
@@ -1608,6 +1610,7 @@ impl EngineConstants {
             ],
             animated_face_table: vec![AnimatedFace { face_id: 0, anim_id: 0, anim_frames: vec![(0, 0)] }],
             string_table: HashMap::new(),
+            missile_flags: vec![200, 201, 202, 218, 550, 766, 880, 920, 1551],
         }
     }
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -7,7 +7,7 @@ use crate::framework::error::GameResult;
 use crate::framework::graphics;
 use crate::input::combined_menu_controller::CombinedMenuController;
 use crate::menu::save_select_menu::MenuSaveInfo;
-use crate::shared_game_state::{MenuCharacter, SharedGameState};
+use crate::shared_game_state::{GameDifficulty, MenuCharacter, SharedGameState};
 
 pub mod pause_menu;
 pub mod save_select_menu;
@@ -434,6 +434,42 @@ impl Menu {
                         &mut state.texture_set,
                         ctx,
                     )?;
+
+                    // Difficulty
+                    if state.constants.is_cs_plus && !state.settings.original_textures {
+                        let difficulty = GameDifficulty::from_save_value(save.difficulty);
+
+                        let batch = state.texture_set.get_or_load_batch(ctx, &state.constants, "MyChar")?;
+                        batch.add_rect(
+                            self.x as f32 + 20.0,
+                            y + 10.0,
+                            &Rect::new_size(
+                                0,
+                                GameDifficulty::get_skinsheet_offset(difficulty).saturating_mul(4 * 16),
+                                16,
+                                16,
+                            ),
+                        );
+                        batch.draw(ctx)?;
+                    } else {
+                        let mut difficulty_name: String = "Difficulty: ".to_owned();
+
+                        match save.difficulty {
+                            0 => difficulty_name.push_str("Normal"),
+                            2 => difficulty_name.push_str("Easy"),
+                            4 => difficulty_name.push_str("Hard"),
+                            _ => difficulty_name.push_str("(unknown)"),
+                        }
+
+                        state.font.draw_text(
+                            difficulty_name.chars(),
+                            self.x as f32 + 20.0,
+                            y + 10.0,
+                            &state.constants,
+                            &mut state.texture_set,
+                            ctx,
+                        )?;
+                    }
 
                     // Weapons
                     let batch = state.texture_set.get_or_load_batch(ctx, &state.constants, "ArmsImage")?;

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -437,18 +437,13 @@ impl Menu {
 
                     // Difficulty
                     if state.constants.is_cs_plus && !state.settings.original_textures {
-                        let difficulty = GameDifficulty::from_save_value(save.difficulty);
+                        let difficulty = GameDifficulty::from_primitive(save.difficulty);
 
                         let batch = state.texture_set.get_or_load_batch(ctx, &state.constants, "MyChar")?;
                         batch.add_rect(
                             self.x as f32 + 20.0,
                             y + 10.0,
-                            &Rect::new_size(
-                                0,
-                                GameDifficulty::get_skinsheet_offset(difficulty).saturating_mul(4 * 16),
-                                16,
-                                16,
-                            ),
+                            &Rect::new_size(0, (difficulty as u16).saturating_mul(2 * 16), 16, 16),
                         );
                         batch.draw(ctx)?;
                     } else {

--- a/src/menu/save_select_menu.rs
+++ b/src/menu/save_select_menu.rs
@@ -149,8 +149,18 @@ impl SaveSelectMenu {
                 MenuSelectionResult::Selected(4, _) | MenuSelectionResult::Canceled => {
                     self.current_menu = CurrentMenu::SaveMenu;
                 }
-                MenuSelectionResult::Selected(item, _) => {
-                    state.difficulty = GameDifficulty::from_index(item - 1);
+                MenuSelectionResult::Selected(1, _) => {
+                    state.difficulty = GameDifficulty::Easy;
+                    state.reload_resources(ctx)?;
+                    state.load_or_start_game(ctx)?;
+                }
+                MenuSelectionResult::Selected(2, _) => {
+                    state.difficulty = GameDifficulty::Normal;
+                    state.reload_resources(ctx)?;
+                    state.load_or_start_game(ctx)?;
+                }
+                MenuSelectionResult::Selected(3, _) => {
+                    state.difficulty = GameDifficulty::Hard;
                     state.reload_resources(ctx)?;
                     state.load_or_start_game(ctx)?;
                 }

--- a/src/menu/save_select_menu.rs
+++ b/src/menu/save_select_menu.rs
@@ -33,6 +33,7 @@ pub struct SaveSelectMenu {
     save_menu: Menu,
     difficulty_menu: Menu,
     delete_confirm: Menu,
+    skip_difficulty_menu: bool,
 }
 
 impl SaveSelectMenu {
@@ -43,6 +44,7 @@ impl SaveSelectMenu {
             save_menu: Menu::new(0, 0, 230, 0),
             difficulty_menu: Menu::new(0, 0, 130, 0),
             delete_confirm: Menu::new(0, 0, 75, 0),
+            skip_difficulty_menu: false,
         }
     }
 
@@ -50,6 +52,7 @@ impl SaveSelectMenu {
         self.save_menu = Menu::new(0, 0, 230, 0);
         self.difficulty_menu = Menu::new(0, 0, 130, 0);
         self.delete_confirm = Menu::new(0, 0, 75, 0);
+        self.skip_difficulty_menu = false;
 
         for (iter, save) in self.saves.iter_mut().enumerate() {
             if let Ok(data) = filesystem::user_open(ctx, state.get_save_filename(iter + 1).unwrap_or("".to_string())) {
@@ -90,6 +93,10 @@ impl SaveSelectMenu {
         Ok(())
     }
 
+    pub fn set_skip_difficulty_menu(&mut self, skip: bool) {
+        self.skip_difficulty_menu = skip;
+    }
+
     fn update_sizes(&mut self, state: &SharedGameState) {
         self.save_menu.update_height();
         self.save_menu.x = ((state.canvas_size.0 - self.save_menu.width as f32) / 2.0).floor() as isize;
@@ -117,7 +124,10 @@ impl SaveSelectMenu {
                 MenuSelectionResult::Selected(slot, _) => {
                     state.save_slot = slot + 1;
 
-                    if let Ok(_) =
+                    if self.skip_difficulty_menu {
+                        state.reload_resources(ctx)?;
+                        state.load_or_start_game(ctx)?;
+                    } else if let Ok(_) =
                         filesystem::user_open(ctx, state.get_save_filename(state.save_slot).unwrap_or("".to_string()))
                     {
                         state.reload_resources(ctx)?;

--- a/src/menu/save_select_menu.rs
+++ b/src/menu/save_select_menu.rs
@@ -5,7 +5,7 @@ use crate::input::combined_menu_controller::CombinedMenuController;
 use crate::menu::MenuEntry;
 use crate::menu::{Menu, MenuSelectionResult};
 use crate::profile::GameProfile;
-use crate::shared_game_state::SharedGameState;
+use crate::shared_game_state::{GameDifficulty, SharedGameState};
 
 #[derive(Clone, Copy)]
 pub struct MenuSaveInfo {
@@ -14,21 +14,24 @@ pub struct MenuSaveInfo {
     pub life: u16,
     pub weapon_count: usize,
     pub weapon_id: [u32; 8],
+    pub difficulty: u8,
 }
 
 impl Default for MenuSaveInfo {
     fn default() -> Self {
-        MenuSaveInfo { current_map: 0, max_life: 0, life: 0, weapon_count: 0, weapon_id: [0; 8] }
+        MenuSaveInfo { current_map: 0, max_life: 0, life: 0, weapon_count: 0, weapon_id: [0; 8], difficulty: 0 }
     }
 }
 pub enum CurrentMenu {
     SaveMenu,
+    DifficultyMenu,
     DeleteConfirm,
 }
 pub struct SaveSelectMenu {
     pub saves: [MenuSaveInfo; 3],
     current_menu: CurrentMenu,
     save_menu: Menu,
+    difficulty_menu: Menu,
     delete_confirm: Menu,
 }
 
@@ -37,13 +40,15 @@ impl SaveSelectMenu {
         SaveSelectMenu {
             saves: [MenuSaveInfo::default(); 3],
             current_menu: CurrentMenu::SaveMenu,
-            save_menu: Menu::new(0, 0, 200, 0),
+            save_menu: Menu::new(0, 0, 230, 0),
+            difficulty_menu: Menu::new(0, 0, 130, 0),
             delete_confirm: Menu::new(0, 0, 75, 0),
         }
     }
 
     pub fn init(&mut self, state: &mut SharedGameState, ctx: &Context) -> GameResult {
-        self.save_menu = Menu::new(0, 0, 200, 0);
+        self.save_menu = Menu::new(0, 0, 230, 0);
+        self.difficulty_menu = Menu::new(0, 0, 130, 0);
         self.delete_confirm = Menu::new(0, 0, 75, 0);
 
         for (iter, save) in self.saves.iter_mut().enumerate() {
@@ -55,6 +60,7 @@ impl SaveSelectMenu {
                 save.life = loaded_save.life;
                 save.weapon_count = loaded_save.weapon_data.iter().filter(|weapon| weapon.weapon_id != 0).count();
                 save.weapon_id = loaded_save.weapon_data.map(|weapon| weapon.weapon_id);
+                save.difficulty = loaded_save.difficulty;
 
                 self.save_menu.push_entry(MenuEntry::SaveData(*save));
             } else {
@@ -64,6 +70,14 @@ impl SaveSelectMenu {
 
         self.save_menu.push_entry(MenuEntry::Active("< Back".to_owned()));
         self.save_menu.push_entry(MenuEntry::Disabled("Press Right to Delete".to_owned()));
+
+        self.difficulty_menu.push_entry(MenuEntry::Disabled("Select Difficulty".to_owned()));
+        self.difficulty_menu.push_entry(MenuEntry::Active("Easy".to_owned()));
+        self.difficulty_menu.push_entry(MenuEntry::Active("Normal".to_owned()));
+        self.difficulty_menu.push_entry(MenuEntry::Active("Hard".to_owned()));
+        self.difficulty_menu.push_entry(MenuEntry::Active("< Back".to_owned()));
+
+        self.difficulty_menu.selected = 2;
 
         self.delete_confirm.push_entry(MenuEntry::Disabled("Delete?".to_owned()));
         self.delete_confirm.push_entry(MenuEntry::Active("Yes".to_owned()));
@@ -80,6 +94,10 @@ impl SaveSelectMenu {
         self.save_menu.update_height();
         self.save_menu.x = ((state.canvas_size.0 - self.save_menu.width as f32) / 2.0).floor() as isize;
         self.save_menu.y = 30 + ((state.canvas_size.1 - self.save_menu.height as f32) / 2.0).floor() as isize;
+        self.difficulty_menu.update_height();
+        self.difficulty_menu.x = ((state.canvas_size.0 - self.difficulty_menu.width as f32) / 2.0).floor() as isize;
+        self.difficulty_menu.y =
+            30 + ((state.canvas_size.1 - self.difficulty_menu.height as f32) / 2.0).floor() as isize;
         self.delete_confirm.update_height();
         self.delete_confirm.x = ((state.canvas_size.0 - self.delete_confirm.width as f32) / 2.0).floor() as isize;
         self.delete_confirm.y = 30 + ((state.canvas_size.1 - self.delete_confirm.height as f32) / 2.0).floor() as isize
@@ -95,27 +113,36 @@ impl SaveSelectMenu {
         self.update_sizes(state);
         match self.current_menu {
             CurrentMenu::SaveMenu => match self.save_menu.tick(controller, state) {
-                MenuSelectionResult::Selected(0, _) => {
-                    state.save_slot = 1;
-                    state.reload_resources(ctx)?;
-                    state.load_or_start_game(ctx)?;
-                }
-                MenuSelectionResult::Selected(1, _) => {
-                    state.save_slot = 2;
-                    state.reload_resources(ctx)?;
-                    state.load_or_start_game(ctx)?;
-                }
-                MenuSelectionResult::Selected(2, _) => {
-                    state.save_slot = 3;
-                    state.reload_resources(ctx)?;
-                    state.load_or_start_game(ctx)?;
-                }
                 MenuSelectionResult::Selected(3, _) | MenuSelectionResult::Canceled => exit_action(),
+                MenuSelectionResult::Selected(slot, _) => {
+                    state.save_slot = slot + 1;
+
+                    if let Ok(_) =
+                        filesystem::user_open(ctx, state.get_save_filename(state.save_slot).unwrap_or("".to_string()))
+                    {
+                        state.reload_resources(ctx)?;
+                        state.load_or_start_game(ctx)?;
+                    } else {
+                        self.difficulty_menu.selected = 2;
+                        self.current_menu = CurrentMenu::DifficultyMenu;
+                    }
+                }
                 MenuSelectionResult::Right(slot, _, _) => {
                     if slot <= 2 {
                         self.current_menu = CurrentMenu::DeleteConfirm;
                         self.delete_confirm.selected = 2;
                     }
+                }
+                _ => (),
+            },
+            CurrentMenu::DifficultyMenu => match self.difficulty_menu.tick(controller, state) {
+                MenuSelectionResult::Selected(4, _) | MenuSelectionResult::Canceled => {
+                    self.current_menu = CurrentMenu::SaveMenu;
+                }
+                MenuSelectionResult::Selected(item, _) => {
+                    state.difficulty = GameDifficulty::from_index(item - 1);
+                    state.reload_resources(ctx)?;
+                    state.load_or_start_game(ctx)?;
                 }
                 _ => (),
             },
@@ -143,6 +170,9 @@ impl SaveSelectMenu {
         match self.current_menu {
             CurrentMenu::SaveMenu => {
                 self.save_menu.draw(state, ctx)?;
+            }
+            CurrentMenu::DifficultyMenu => {
+                self.difficulty_menu.draw(state, ctx)?;
             }
             CurrentMenu::DeleteConfirm => {
                 self.delete_confirm.draw(state, ctx)?;

--- a/src/npc/ai/misc.rs
+++ b/src/npc/ai/misc.rs
@@ -9,7 +9,7 @@ use crate::npc::list::NPCList;
 use crate::npc::{NPCLayer, NPC};
 use crate::player::Player;
 use crate::rng::RNG;
-use crate::shared_game_state::SharedGameState;
+use crate::shared_game_state::{GameDifficulty, SharedGameState};
 use crate::stage::Stage;
 
 impl NPC {
@@ -137,6 +137,11 @@ impl NPC {
     }
 
     pub(crate) fn tick_n015_chest_closed(&mut self, state: &mut SharedGameState, npc_list: &NPCList) -> GameResult {
+        if state.difficulty == GameDifficulty::Hard && self.chest_has_missile_flag() {
+            self.cond.set_alive(false);
+            return Ok(());
+        }
+
         match self.action_num {
             0 | 1 => {
                 if self.action_num == 0 {
@@ -332,6 +337,11 @@ impl NPC {
     }
 
     pub(crate) fn tick_n021_chest_open(&mut self, state: &mut SharedGameState) -> GameResult {
+        if state.difficulty == GameDifficulty::Hard && self.chest_has_missile_flag() {
+            self.cond.set_alive(false);
+            return Ok(());
+        }
+
         if self.action_num == 0 {
             self.action_num = 1;
 
@@ -429,6 +439,11 @@ impl NPC {
     }
 
     pub(crate) fn tick_n032_life_capsule(&mut self, state: &mut SharedGameState) -> GameResult {
+        if state.difficulty == GameDifficulty::Hard {
+            self.cond.set_alive(false);
+            return Ok(());
+        }
+
         self.anim_counter = (self.anim_counter + 1) % 4;
         self.anim_num = self.anim_counter / 2;
         self.anim_rect = state.constants.npc.n032_life_capsule[self.anim_num as usize];
@@ -2608,5 +2623,10 @@ impl NPC {
         self.anim_rect = state.constants.npc.n360_credits_thank_you;
 
         Ok(())
+    }
+
+    fn chest_has_missile_flag(&self) -> bool {
+        let missile_flags: [u16; 9] = [200, 201, 202, 218, 550, 766, 880, 920, 1551];
+        missile_flags.contains(&self.flag_num)
     }
 }

--- a/src/npc/ai/misc.rs
+++ b/src/npc/ai/misc.rs
@@ -137,7 +137,7 @@ impl NPC {
     }
 
     pub(crate) fn tick_n015_chest_closed(&mut self, state: &mut SharedGameState, npc_list: &NPCList) -> GameResult {
-        if state.difficulty == GameDifficulty::Hard && self.chest_has_missile_flag() {
+        if state.difficulty == GameDifficulty::Hard && state.constants.missile_flags.contains(&self.flag_num) {
             self.cond.set_alive(false);
             return Ok(());
         }
@@ -337,7 +337,7 @@ impl NPC {
     }
 
     pub(crate) fn tick_n021_chest_open(&mut self, state: &mut SharedGameState) -> GameResult {
-        if state.difficulty == GameDifficulty::Hard && self.chest_has_missile_flag() {
+        if state.difficulty == GameDifficulty::Hard && state.constants.missile_flags.contains(&self.flag_num) {
             self.cond.set_alive(false);
             return Ok(());
         }
@@ -2623,10 +2623,5 @@ impl NPC {
         self.anim_rect = state.constants.npc.n360_credits_thank_you;
 
         Ok(())
-    }
-
-    fn chest_has_missile_flag(&self) -> bool {
-        let missile_flags: [u16; 9] = [200, 201, 202, 218, 550, 766, 880, 920, 1551];
-        missile_flags.contains(&self.flag_num)
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -839,13 +839,15 @@ impl Player {
             self.vel_y = -0x400; // -2.0fix9
         }
 
-        self.life = self.life.saturating_sub(hp as u16);
+        let final_hp = state.get_damage(hp);
+
+        self.life = self.life.saturating_sub(final_hp as u16);
 
         if self.equip.has_whimsical_star() && self.stars > 0 {
             self.stars -= 1;
         }
 
-        self.damage = self.damage.saturating_add(hp as u16);
+        self.damage = self.damage.saturating_add(final_hp as u16);
         if self.popup.value > 0 {
             self.popup.set_value(-(self.damage as i16));
         } else {

--- a/src/player/skin/basic.rs
+++ b/src/player/skin/basic.rs
@@ -119,7 +119,7 @@ impl BasicPlayerSkin {
     fn get_y_offset_by(&self, y: u16) -> u16 {
         return self
             .skinsheet_offset
-            .saturating_mul(self.metadata.frame_size_height.saturating_mul(4))
+            .saturating_mul(self.metadata.frame_size_height.saturating_mul(2))
             .saturating_add(y);
     }
 }

--- a/src/player/skin/mod.rs
+++ b/src/player/skin/mod.rs
@@ -1,5 +1,6 @@
 use crate::bitfield;
 use crate::common::{Color, Direction, Rect};
+use crate::shared_game_state::SharedGameState;
 
 pub mod basic;
 
@@ -92,6 +93,9 @@ pub trait PlayerSkin: PlayerSkinClone {
 
     /// Returns Whimsical Star rect location
     fn get_whimsical_star_rect(&self, index: usize) -> Rect<u16>;
+
+    /// Applies modifications on the skin based on current state
+    fn apply_gamestate(&mut self, state: &SharedGameState);
 }
 
 pub trait PlayerSkinClone {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -147,7 +147,7 @@ impl GameProfile {
 
         game_scene.player1.cond.0 = 0x80;
 
-        state.difficulty = GameDifficulty::from_save_value(self.difficulty);
+        state.difficulty = GameDifficulty::from_primitive(self.difficulty);
 
         game_scene.player1.skin.apply_gamestate(state);
         game_scene.player2.skin.apply_gamestate(state);
@@ -236,7 +236,7 @@ impl GameProfile {
         }
 
         let timestamp = get_timestamp();
-        let difficulty = state.difficulty.to_save_value();
+        let difficulty = state.difficulty as u8;
 
         GameProfile {
             current_map,

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -13,7 +13,7 @@ use crate::menu::settings_menu::SettingsMenu;
 use crate::menu::{Menu, MenuEntry, MenuSelectionResult};
 use crate::scene::jukebox_scene::JukeboxScene;
 use crate::scene::Scene;
-use crate::shared_game_state::{MenuCharacter, SharedGameState, TileSize};
+use crate::shared_game_state::{GameDifficulty, MenuCharacter, SharedGameState, TileSize};
 use crate::stage::{BackgroundType, NpcType, Stage, StageData, StageTexturePaths, Tileset};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
@@ -200,6 +200,7 @@ impl Scene for TitleScene {
                 MenuSelectionResult::Selected(0, _) => {
                     state.mod_path = None;
                     self.save_select_menu.init(state, ctx)?;
+                    self.save_select_menu.set_skip_difficulty_menu(false);
                     self.current_menu = CurrentMenu::SaveSelectMenu;
                 }
                 MenuSelectionResult::Selected(1, _) => {
@@ -263,6 +264,7 @@ impl Scene for TitleScene {
                             state.mod_path = Some(mod_info.path.clone());
                             if mod_info.save_slot >= 0 {
                                 self.save_select_menu.init(state, ctx)?;
+                                self.save_select_menu.set_skip_difficulty_menu(true);
                                 self.nikumaru_rec.load_counter(state, ctx)?;
                                 self.current_menu = CurrentMenu::SaveSelectMenu;
                             } else {
@@ -285,6 +287,7 @@ impl Scene for TitleScene {
             }
             CurrentMenu::ChallengeConfirmMenu => match self.confirm_menu.tick(&mut self.controller, state) {
                 MenuSelectionResult::Selected(1, _) => {
+                    state.difficulty = GameDifficulty::Normal;
                     state.reload_resources(ctx)?;
                     state.start_new_game(ctx)?;
                 }

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -67,46 +67,16 @@ impl TimingMode {
     }
 }
 
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, num_derive::FromPrimitive)]
 pub enum GameDifficulty {
-    Easy,
-    Normal,
-    Hard,
+    Normal = 0,
+    Easy = 2,
+    Hard = 4,
 }
 
 impl GameDifficulty {
-    pub fn from_index(index: usize) -> GameDifficulty {
-        match index {
-            0 => GameDifficulty::Easy,
-            1 => GameDifficulty::Normal,
-            2 => GameDifficulty::Hard,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn from_save_value(val: u8) -> GameDifficulty {
-        match val {
-            0 => GameDifficulty::Normal,
-            2 => GameDifficulty::Easy,
-            4 => GameDifficulty::Hard,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn to_save_value(self) -> u8 {
-        match self {
-            GameDifficulty::Normal => 0,
-            GameDifficulty::Easy => 2,
-            GameDifficulty::Hard => 4,
-        }
-    }
-
-    pub fn get_skinsheet_offset(difficulty: GameDifficulty) -> u16 {
-        match difficulty {
-            GameDifficulty::Easy => 1,   // Yellow Quote
-            GameDifficulty::Normal => 0, // Good Quote
-            GameDifficulty::Hard => 2,   // Human Quote
-        }
+    pub fn from_primitive(val: u8) -> GameDifficulty {
+        return num_traits::FromPrimitive::from_u8(val).unwrap_or(GameDifficulty::Normal);
     }
 }
 
@@ -654,6 +624,6 @@ impl SharedGameState {
             }
         }
 
-        GameDifficulty::get_skinsheet_offset(self.difficulty)
+        return self.difficulty as u16;
     }
 }


### PR DESCRIPTION
Difficulties work the same way as in CS+, meaning:

- easy difficulty will halve the damage you take
- hard difficulty will remove life capsules (except for the puppy capsule) and missile chests

The difficulties can be selected using any data files (including freeware), with the exception that difficulty-based skins will only be applied if you've loaded up CS+ data files and have original textures set to off.

Creating a new game now brings up a difficulty selection screen:

![image](https://user-images.githubusercontent.com/20266711/155878561-a17a739c-45cd-46ee-b74d-ec92253949e8.png)

Skins will vary based on difficulty (however, original and seasonal textures will always take precedence). This modification is done to the basic player skin, so it doesn't lock the logic to the global skin structure.

![image](https://user-images.githubusercontent.com/20266711/155878804-5f83c06a-a141-4d2e-a63c-5d98eb605a67.png)

Difficulties are also saved in the profile (in the same way and byte offset CS+ stores them).

In the save selection menu, if you use CS+ data files and original textures are off, the skin will indicate the difficulty:

![image](https://user-images.githubusercontent.com/20266711/155878753-058b7353-c324-486e-9e13-1931d4998db6.png)

In other cases, a simple text will indicate the difficulty:

![image](https://user-images.githubusercontent.com/20266711/155878775-d6d1bc19-b220-494c-a85a-a5d97e5371e6.png)

As an added bonus, seasonal textures will also apply to Quote's skin.

(Note: this is a draft because challenges are currently affected by difficulty)