### PR TITLE
prevent stray bytes from disallowing subsequent events

### DIFF
--- a/src/scripting/tsc/compiler.rs
+++ b/src/scripting/tsc/compiler.rs
@@ -116,7 +116,6 @@ impl TextScript {
                     iter.next();
                 }
                 _ => {
-                    allow_next_event = false;
                     char_buf.push(chr);
 
                     iter.next();


### PR DESCRIPTION
Events that have stray bytes between an event and the start of another event did not get compiled. The change makes it so any byte apart from #, <, and newline chars will not disable the compilation of subsequent events. Instead, it will let whatever's before these bytes to say whether or not the next events should be parsed (tldr: it shouldn't break anything).

Example for an event that didn't get compiled because of this:

![thank you nicalis](https://user-images.githubusercontent.com/20266711/156541647-2c50c07c-9e01-4dfb-b096-323632d3646a.png)

Fixes #73.