### PR TITLE
Basic i18n support

### DIFF
--- a/src/builtin/locale/en.json
+++ b/src/builtin/locale/en.json
@@ -1,0 +1,102 @@
+{
+  "common": {
+    "name": "doukutsu-rs",
+    "back": "< Back",
+    "yes": "Yes",
+    "no": "No",
+    "on": "ON",
+    "off": "OFF"
+  },
+
+  "menus": {
+    "main_menu": {
+      "start": "Start Game",
+      "challenges": "Challenges",
+      "options": "Options",
+      "editor": "Editor",
+      "jukebox": "Jukebox",
+      "quit": "Quit"
+    },
+
+    "pause_menu": {
+      "resume": "Resume",
+      "retry": "Retry",
+      "options": "Options",
+      "title": "Title",
+      "title_confirm": "Title?",
+      "quit": "Quit",
+      "quit_confirm": "Quit?"
+    },
+
+    "save_menu": {
+      "new": "New Save",
+      "delete_info": "Press Right to Delete",
+      "delete_confirm": "Delete?"
+    },
+
+    "difficulty_menu": {
+      "title": "Select Difficulty",
+      "easy": "Easy",
+      "normal": "Normal",
+      "hard": "Hard"
+    },
+
+    "challenge_menu": {
+      "start": "Start",
+      "no_replay": "No Replay",
+      "replay_best": "Replay Best"
+    },
+
+    "options_menu": {
+      "graphics": "Graphics...",
+      "graphics_menu": {
+        "lighting_effects": "Lighting effects:",
+        "weapon_light_cone": "Weapon light cone:",
+        "motion_interpolation": "Motion interpolation:",
+        "subpixel_scrolling": "Subpixel scrolling:",
+        "original_textures": "Original textures:",
+        "seasonal_textures": "Seasonal textures:",
+        "renderer": "Renderer:"
+      },
+
+      "sound": "Sound...",
+      "sound_menu": {
+        "music_volume": "Music Volume",
+        "effects_volume": "Effects Volume",
+        "bgm_interpolation": {
+          "entry": "BGM Interpolation:",
+          "linear": "Linear",
+          "linear_desc": "Fast, similar to freeware on Vista+",
+          "cosine": "Cosine",
+          "cosine_desc": "Cosine interpolation",
+          "cubic": "Cubic",
+          "cubic_desc": "Cubic interpolation",
+          "linear_lp": "Linear+LP",
+          "linear_lp_desc": "Slowest, similar to freeware on XP",
+          "nearest": "Nearest",
+          "nearest_desc": "Fastest, lowest quality"
+        },
+        "soundtrack": "Soundtrack: {soundtrack}"
+      },
+
+      "language": "Language...",
+
+      "game_timing": {
+        "entry": "Game timing:",
+        "50tps": "50tps (freeware)",
+        "60tps": "60tps (CS+)"
+      }
+    }
+  },
+
+  "soundtrack": {
+    "organya": "Organya",
+    "remastered": "Remastered",
+    "new": "New",
+    "famitracks": "Famitracks"
+  },
+
+  "game": {
+    "cutscene_skip": "Hold {key} to skip the cutscene"
+  }
+}

--- a/src/builtin/locale/jp.json
+++ b/src/builtin/locale/jp.json
@@ -1,0 +1,102 @@
+{
+  "common": {
+    "name": "doukutsu-rs",
+    "back": "< Back",
+    "yes": "はい",
+    "no": "いいえ",
+    "on": "オン",
+    "off": "オフ"
+  },
+
+  "menus": {
+    "main_menu": {
+      "start": "Start Game",
+      "challenges": "チャレンジ",
+      "options": "Options",
+      "editor": "Editor",
+      "jukebox": "ジュークボックス",
+      "quit": "Quit"
+    },
+
+    "pause_menu": {
+      "resume": "Resume",
+      "retry": "Retry",
+      "options": "Options",
+      "title": "Title",
+      "title_confirm": "Title?",
+      "quit": "Quit",
+      "quit_confirm": "Quit?"
+    },
+
+    "save_menu": {
+      "new": "New Save",
+      "delete_info": "Press Right to Delete",
+      "delete_confirm": "Delete?"
+    },
+
+    "difficulty_menu": {
+      "title": "Select Difficulty",
+      "easy": "Easy",
+      "normal": "Normal",
+      "hard": "Hard"
+    },
+
+    "challenge_menu": {
+      "start": "Start",
+      "no_replay": "No Replay",
+      "replay_best": "Replay Best"
+    },
+
+    "options_menu": {
+      "graphics": "Graphics...",
+      "graphics_menu": {
+        "lighting_effects": "Lighting effects:",
+        "weapon_light_cone": "Weapon light cone:",
+        "motion_interpolation": "Motion interpolation:",
+        "subpixel_scrolling": "Subpixel scrolling:",
+        "original_textures": "Original textures:",
+        "seasonal_textures": "Seasonal textures:",
+        "renderer": "Renderer:"
+      },
+
+      "sound": "Sound...",
+      "sound_menu": {
+        "music_volume": "BGM音量",
+        "effects_volume": "サウンド音量",
+        "bgm_interpolation": {
+          "entry": "BGM Interpolation:",
+          "linear": "Linear",
+          "linear_desc": "Fast, similar to freeware on Vista+",
+          "cosine": "Cosine",
+          "cosine_desc": "Cosine interpolation",
+          "cubic": "Cubic",
+          "cubic_desc": "Cubic interpolation",
+          "linear_lp": "Linear+LP",
+          "linear_lp_desc": "Slowest, similar to freeware on XP",
+          "nearest": "Nearest",
+          "nearest_desc": "Fastest, lowest quality"
+        },
+        "soundtrack": "Soundtrack: {soundtrack}"
+      },
+
+      "language": "Language...",
+
+      "game_timing": {
+        "entry": "Game timing:",
+        "50tps": "50tps (freeware)",
+        "60tps": "60tps (CS+)"
+      }
+    }
+  },
+
+  "soundtrack": {
+    "organya": "オルガーニャ",
+    "remastered": "リマスター",
+    "new": "New",
+    "famitracks": "ファミトラック"
+  },
+
+  "game": {
+    "cutscene_skip": "{key} を押し続け、カットシーンをスキップ"
+  }
+}

--- a/src/builtin/locale/jp.json
+++ b/src/builtin/locale/jp.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "doukutsu-rs",
-    "back": "< Back",
+    "back": "< 戻る",
     "yes": "はい",
     "no": "いいえ",
     "on": "オン",
@@ -10,79 +10,79 @@
 
   "menus": {
     "main_menu": {
-      "start": "Start Game",
+      "start": "ゲームスタート",
       "challenges": "チャレンジ",
-      "options": "Options",
-      "editor": "Editor",
+      "options": "設定",
+      "editor": "レベルエディタ",
       "jukebox": "ジュークボックス",
-      "quit": "Quit"
+      "quit": "辞める"
     },
 
     "pause_menu": {
-      "resume": "Resume",
-      "retry": "Retry",
-      "options": "Options",
-      "title": "Title",
-      "title_confirm": "Title?",
-      "quit": "Quit",
-      "quit_confirm": "Quit?"
+      "resume": "再開",
+      "retry": "リトライ",
+      "options": "設定",
+      "title": "メインメニュー",
+      "title_confirm": "メインメニュー？",
+      "quit": "辞める",
+      "quit_confirm": "辞める？"
     },
 
     "save_menu": {
-      "new": "New Save",
-      "delete_info": "Press Right to Delete",
-      "delete_confirm": "Delete?"
+      "new": "新しいデータ",
+      "delete_info": "右矢印キーで削除",
+      "delete_confirm": "消去？"
     },
 
     "difficulty_menu": {
-      "title": "Select Difficulty",
-      "easy": "Easy",
-      "normal": "Normal",
-      "hard": "Hard"
+      "title": "難易度選択",
+      "easy": "簡単",
+      "normal": "普通",
+      "hard": "難しい"
     },
 
     "challenge_menu": {
-      "start": "Start",
-      "no_replay": "No Replay",
-      "replay_best": "Replay Best"
+      "start": "スタート",
+      "no_replay": "ノーリプレイ",
+      "replay_best": "ベストプレイを再生"
     },
 
     "options_menu": {
-      "graphics": "Graphics...",
+      "graphics": "グラフィック",
       "graphics_menu": {
-        "lighting_effects": "Lighting effects:",
-        "weapon_light_cone": "Weapon light cone:",
-        "motion_interpolation": "Motion interpolation:",
-        "subpixel_scrolling": "Subpixel scrolling:",
-        "original_textures": "Original textures:",
-        "seasonal_textures": "Seasonal textures:",
-        "renderer": "Renderer:"
+        "lighting_effects": "ライティング効果：",
+        "weapon_light_cone": "兵器のライトコーン：",
+        "motion_interpolation": "モーション補間：",
+        "subpixel_scrolling": "サブピクセルスクロール：",
+        "original_textures": "オリジナルテクスチャ：",
+        "seasonal_textures": "季節ものテクスチャ：",
+        "renderer": "レンダラ："
       },
 
-      "sound": "Sound...",
+      "sound": "サウンド",
       "sound_menu": {
         "music_volume": "BGM音量",
         "effects_volume": "サウンド音量",
         "bgm_interpolation": {
-          "entry": "BGM Interpolation:",
-          "linear": "Linear",
-          "linear_desc": "Fast, similar to freeware on Vista+",
-          "cosine": "Cosine",
-          "cosine_desc": "Cosine interpolation",
-          "cubic": "Cubic",
-          "cubic_desc": "Cubic interpolation",
-          "linear_lp": "Linear+LP",
-          "linear_lp_desc": "Slowest, similar to freeware on XP",
-          "nearest": "Nearest",
-          "nearest_desc": "Fastest, lowest quality"
+          "entry": "BGM内挿：",
+          "linear": "線形補間",
+          "linear_desc": "速い、フリーウェア版に近い（Vista+）",
+          "cosine": "余弦",
+          "cosine_desc": "余弦補間",
+          "cubic": "立方体",
+          "cubic_desc": "立方体補間",
+          "linear_lp": "線形補間+LP",
+          "linear_lp_desc": "最も遅い、フリーウェア版に近い（XP）",
+          "nearest": "最近傍",
+          "nearest_desc": "最速、最低品質"
         },
-        "soundtrack": "Soundtrack: {soundtrack}"
+        "soundtrack": "サウンドトラック： {soundtrack}"
       },
 
-      "language": "Language...",
+      "language": "言語",
 
       "game_timing": {
-        "entry": "Game timing:",
+        "entry": "ゲームのタイミング：",
         "50tps": "50tps (freeware)",
         "60tps": "60tps (CS+)"
       }
@@ -92,7 +92,7 @@
   "soundtrack": {
     "organya": "オルガーニャ",
     "remastered": "リマスター",
-    "new": "New",
+    "new": "新",
     "famitracks": "ファミトラック"
   },
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,63 @@
+use crate::framework::context::Context;
+use crate::framework::filesystem;
+use crate::shared_game_state::FontData;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Locale {
+    strings: HashMap<String, String>,
+    pub font: FontData,
+}
+
+impl Locale {
+    pub fn new(ctx: &mut Context, code: &str, font: FontData) -> Locale {
+        let mut filename = "en.json".to_owned();
+
+        if code != "en" && filesystem::exists(ctx, &format!("/builtin/locale/{}.json", code)) {
+            filename = format!("{}.json", code);
+        }
+
+        let file = filesystem::open(ctx, &format!("/builtin/locale/{}", filename)).unwrap();
+        let json: serde_json::Value = serde_json::from_reader(file).unwrap();
+
+        let strings = Locale::flatten(&json);
+
+        Locale { strings, font }
+    }
+
+    fn flatten(json: &serde_json::Value) -> HashMap<String, String> {
+        let mut strings = HashMap::new();
+
+        for (key, value) in json.as_object().unwrap() {
+            match value {
+                serde_json::Value::String(string) => {
+                    strings.insert(key.to_owned(), string.to_owned());
+                }
+                serde_json::Value::Object(_) => {
+                    let substrings = Locale::flatten(value);
+
+                    for (sub_key, sub_value) in substrings.iter() {
+                        strings.insert(format!("{}.{}", key, sub_key), sub_value.to_owned());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        strings
+    }
+
+    pub fn t(&self, key: &str) -> String {
+        self.strings.get(key).unwrap_or(&key.to_owned()).to_owned()
+    }
+
+    pub fn tt(&self, key: &str, args: HashMap<String, String>) -> String {
+        let mut string = self.t(key);
+
+        for (key, value) in args.iter() {
+            string = string.replace(&format!("{{{}}}", key), &value);
+        }
+
+        string
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod frame;
 mod framework;
 #[cfg(feature = "hooks")]
 mod hooks;
+mod i18n;
 mod input;
 mod inventory;
 mod live_debugger;

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -156,7 +156,8 @@ impl Menu {
             }
         }
 
-        self.width = width.max(16.0) as u16;
+        width = width.max(16.0);
+        self.width = if (width + 4.0) % 8.0 != 0.0 { (width + 4.0 - width % 8.0) as u16 } else { width as u16 };
     }
 
     pub fn update_height(&mut self) {

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -410,7 +410,7 @@ impl Menu {
                 }
                 MenuEntry::NewSave => {
                     state.font.draw_text(
-                        "New Save".chars(),
+                        state.t("menus.save_menu.new").chars(),
                         self.x as f32 + 20.0,
                         y,
                         &state.constants,

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -97,6 +97,68 @@ impl Menu {
         self.entries.push(entry);
     }
 
+    pub fn update_width(&mut self, state: &SharedGameState) {
+        let mut width = self.width as f32;
+
+        for entry in &self.entries {
+            match entry {
+                MenuEntry::Hidden => {}
+                MenuEntry::Active(entry) | MenuEntry::DisabledWhite(entry) | MenuEntry::Disabled(entry) => {
+                    let entry_width = state.font.text_width(entry.chars(), &state.constants) + 32.0;
+                    width = width.max(entry_width);
+                }
+                MenuEntry::Toggle(entry, _) => {
+                    let mut entry_with_option = entry.clone();
+                    entry_with_option.push_str(" ");
+
+                    let longest_option_width = if state.t("common.off").len() > state.t("common.on").len() {
+                        state.font.text_width(state.t("common.off").chars(), &state.constants)
+                    } else {
+                        state.font.text_width(state.t("common.on").chars(), &state.constants)
+                    };
+
+                    let entry_width = state.font.text_width(entry_with_option.chars(), &state.constants)
+                        + longest_option_width
+                        + 32.0;
+                    width = width.max(entry_width);
+                }
+                MenuEntry::Options(entry, _, options) => {
+                    let mut entry_with_option = entry.clone();
+                    entry_with_option.push_str(" ");
+
+                    let longest_option = options.iter().max_by(|&a, &b| a.len().cmp(&b.len())).unwrap();
+                    entry_with_option.push_str(longest_option);
+
+                    let entry_width = state.font.text_width(entry_with_option.chars(), &state.constants) + 32.0;
+                    width = width.max(entry_width);
+                }
+                MenuEntry::DescriptiveOptions(entry, _, options, descriptions) => {
+                    let mut entry_with_option = entry.clone();
+                    entry_with_option.push_str(" ");
+
+                    let longest_option = options.iter().max_by(|&a, &b| a.len().cmp(&b.len())).unwrap();
+                    entry_with_option.push_str(longest_option);
+
+                    let entry_width = state.font.text_width(entry_with_option.chars(), &state.constants) + 32.0;
+                    width = width.max(entry_width);
+
+                    let longest_description = descriptions.iter().max_by(|&a, &b| a.len().cmp(&b.len())).unwrap();
+                    let description_width = state.font.text_width(longest_description.chars(), &state.constants) + 32.0;
+                    width = width.max(description_width);
+                }
+                MenuEntry::OptionsBar(entry, _) => {
+                    let bar_width = if state.constants.is_switch { 81.0 } else { 109.0 };
+                    let entry_width = state.font.text_width(entry.chars(), &state.constants) + 32.0 + bar_width;
+                    width = width.max(entry_width);
+                }
+                MenuEntry::SaveData(_) => {}
+                MenuEntry::NewSave => {}
+            }
+        }
+
+        self.width = width.max(16.0) as u16;
+    }
+
     pub fn update_height(&mut self) {
         let mut height = 8.0;
 

--- a/src/menu/pause_menu.rs
+++ b/src/menu/pause_menu.rs
@@ -48,15 +48,15 @@ impl PauseMenu {
         self.controller.add(state.settings.create_player1_controller());
         self.controller.add(state.settings.create_player2_controller());
 
-        self.pause_menu.push_entry(MenuEntry::Active("Resume".to_owned()));
-        self.pause_menu.push_entry(MenuEntry::Active("Retry".to_owned()));
-        self.pause_menu.push_entry(MenuEntry::Active("Options".to_owned()));
-        self.pause_menu.push_entry(MenuEntry::Active("Title".to_owned()));
-        self.pause_menu.push_entry(MenuEntry::Active("Quit".to_owned()));
+        self.pause_menu.push_entry(MenuEntry::Active(state.t("menus.pause_menu.resume")));
+        self.pause_menu.push_entry(MenuEntry::Active(state.t("menus.pause_menu.retry")));
+        self.pause_menu.push_entry(MenuEntry::Active(state.t("menus.pause_menu.options")));
+        self.pause_menu.push_entry(MenuEntry::Active(state.t("menus.pause_menu.title")));
+        self.pause_menu.push_entry(MenuEntry::Active(state.t("menus.pause_menu.quit")));
 
         self.confirm_menu.push_entry(MenuEntry::Disabled("".to_owned()));
-        self.confirm_menu.push_entry(MenuEntry::Active("Yes".to_owned()));
-        self.confirm_menu.push_entry(MenuEntry::Active("No".to_owned()));
+        self.confirm_menu.push_entry(MenuEntry::Active(state.t("common.yes")));
+        self.confirm_menu.push_entry(MenuEntry::Active(state.t("common.no")));
 
         self.confirm_menu.selected = 1;
 
@@ -125,11 +125,11 @@ impl PauseMenu {
                     self.current_menu = CurrentMenu::OptionsMenu;
                 }
                 MenuSelectionResult::Selected(3, _) => {
-                    self.confirm_menu.entries[0] = MenuEntry::Disabled("Title?".to_owned());
+                    self.confirm_menu.entries[0] = MenuEntry::Disabled(state.t("menus.pause_menu.title_confirm"));
                     self.current_menu = CurrentMenu::ConfirmMenu;
                 }
                 MenuSelectionResult::Selected(4, _) => {
-                    self.confirm_menu.entries[0] = MenuEntry::Disabled("Quit?".to_owned());
+                    self.confirm_menu.entries[0] = MenuEntry::Disabled(state.t("menus.pause_menu.quit_confirm"));
                     self.current_menu = CurrentMenu::ConfirmMenu;
                 }
                 _ => (),

--- a/src/menu/pause_menu.rs
+++ b/src/menu/pause_menu.rs
@@ -73,9 +73,12 @@ impl PauseMenu {
     }
 
     fn update_sizes(&mut self, state: &SharedGameState) {
+        self.pause_menu.update_width(state);
         self.pause_menu.update_height();
         self.pause_menu.x = ((state.canvas_size.0 - self.pause_menu.width as f32) / 2.0).floor() as isize;
         self.pause_menu.y = ((state.canvas_size.1 - self.pause_menu.height as f32) / 2.0).floor() as isize;
+
+        self.confirm_menu.update_width(state);
         self.confirm_menu.update_height();
         self.confirm_menu.x = ((state.canvas_size.0 - self.confirm_menu.width as f32) / 2.0).floor() as isize;
         self.confirm_menu.y = ((state.canvas_size.1 - self.confirm_menu.height as f32) / 2.0).floor() as isize;

--- a/src/menu/save_select_menu.rs
+++ b/src/menu/save_select_menu.rs
@@ -71,20 +71,20 @@ impl SaveSelectMenu {
             }
         }
 
-        self.save_menu.push_entry(MenuEntry::Active("< Back".to_owned()));
-        self.save_menu.push_entry(MenuEntry::Disabled("Press Right to Delete".to_owned()));
+        self.save_menu.push_entry(MenuEntry::Active(state.t("common.back")));
+        self.save_menu.push_entry(MenuEntry::Disabled(state.t("menus.save_menu.delete_info")));
 
-        self.difficulty_menu.push_entry(MenuEntry::Disabled("Select Difficulty".to_owned()));
-        self.difficulty_menu.push_entry(MenuEntry::Active("Easy".to_owned()));
-        self.difficulty_menu.push_entry(MenuEntry::Active("Normal".to_owned()));
-        self.difficulty_menu.push_entry(MenuEntry::Active("Hard".to_owned()));
-        self.difficulty_menu.push_entry(MenuEntry::Active("< Back".to_owned()));
+        self.difficulty_menu.push_entry(MenuEntry::Disabled(state.t("menus.difficulty_menu.title")));
+        self.difficulty_menu.push_entry(MenuEntry::Active(state.t("menus.difficulty_menu.easy")));
+        self.difficulty_menu.push_entry(MenuEntry::Active(state.t("menus.difficulty_menu.normal")));
+        self.difficulty_menu.push_entry(MenuEntry::Active(state.t("menus.difficulty_menu.hard")));
+        self.difficulty_menu.push_entry(MenuEntry::Active(state.t("common.back")));
 
         self.difficulty_menu.selected = 2;
 
-        self.delete_confirm.push_entry(MenuEntry::Disabled("Delete?".to_owned()));
-        self.delete_confirm.push_entry(MenuEntry::Active("Yes".to_owned()));
-        self.delete_confirm.push_entry(MenuEntry::Active("No".to_owned()));
+        self.delete_confirm.push_entry(MenuEntry::Disabled(state.t("menus.save_menu.delete_confirm")));
+        self.delete_confirm.push_entry(MenuEntry::Active(state.t("common.yes")));
+        self.delete_confirm.push_entry(MenuEntry::Active(state.t("common.no")));
 
         self.delete_confirm.selected = 2;
 

--- a/src/menu/save_select_menu.rs
+++ b/src/menu/save_select_menu.rs
@@ -98,13 +98,18 @@ impl SaveSelectMenu {
     }
 
     fn update_sizes(&mut self, state: &SharedGameState) {
+        self.save_menu.update_width(state);
         self.save_menu.update_height();
         self.save_menu.x = ((state.canvas_size.0 - self.save_menu.width as f32) / 2.0).floor() as isize;
         self.save_menu.y = 30 + ((state.canvas_size.1 - self.save_menu.height as f32) / 2.0).floor() as isize;
+
+        self.difficulty_menu.update_width(state);
         self.difficulty_menu.update_height();
         self.difficulty_menu.x = ((state.canvas_size.0 - self.difficulty_menu.width as f32) / 2.0).floor() as isize;
         self.difficulty_menu.y =
             30 + ((state.canvas_size.1 - self.difficulty_menu.height as f32) / 2.0).floor() as isize;
+
+        self.delete_confirm.update_width(state);
         self.delete_confirm.update_height();
         self.delete_confirm.x = ((state.canvas_size.0 - self.delete_confirm.width as f32) / 2.0).floor() as isize;
         self.delete_confirm.y = 30 + ((state.canvas_size.1 - self.delete_confirm.height as f32) / 2.0).floor() as isize

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -192,22 +192,27 @@ impl SettingsMenu {
     }
 
     fn update_sizes(&mut self, state: &SharedGameState) {
+        self.main.update_width(state);
         self.main.update_height();
         self.main.x = ((state.canvas_size.0 - self.main.width as f32) / 2.0).floor() as isize;
         self.main.y = 30 + ((state.canvas_size.1 - self.main.height as f32) / 2.0).floor() as isize;
 
+        self.graphics.update_width(state);
         self.graphics.update_height();
         self.graphics.x = ((state.canvas_size.0 - self.graphics.width as f32) / 2.0).floor() as isize;
         self.graphics.y = 30 + ((state.canvas_size.1 - self.graphics.height as f32) / 2.0).floor() as isize;
 
+        self.sound.update_width(state);
         self.sound.update_height();
         self.sound.x = ((state.canvas_size.0 - self.sound.width as f32) / 2.0).floor() as isize;
         self.sound.y = 30 + ((state.canvas_size.1 - self.sound.height as f32) / 2.0).floor() as isize;
 
+        self.soundtrack.update_width(state);
         self.soundtrack.update_height();
         self.soundtrack.x = ((state.canvas_size.0 - self.soundtrack.width as f32) / 2.0).floor() as isize;
         self.soundtrack.y = ((state.canvas_size.1 - self.soundtrack.height as f32) / 2.0).floor() as isize;
 
+        self.language.update_width(state);
         self.language.update_height();
         self.language.x = ((state.canvas_size.0 - self.language.width as f32) / 2.0).floor() as isize;
         self.language.y = ((state.canvas_size.1 - self.language.height as f32) / 2.0).floor() as isize;

--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -46,7 +46,7 @@ use crate::scene::title_scene::TitleScene;
 use crate::scene::Scene;
 use crate::scripting::tsc::credit_script::CreditScriptVM;
 use crate::scripting::tsc::text_script::{ScriptMode, TextScriptExecutionState, TextScriptVM};
-use crate::shared_game_state::{ReplayState, SharedGameState, TileSize};
+use crate::shared_game_state::{Language, ReplayState, SharedGameState, TileSize};
 use crate::stage::{BackgroundType, Stage, StageTexturePaths};
 use crate::texture_set::SpriteBatch;
 use crate::weapon::bullet::BulletManager;
@@ -1950,7 +1950,11 @@ impl Scene for GameScene {
             let map_name = if self.stage.data.name == "u" {
                 state.constants.title.intro_text.chars()
             } else {
-                self.stage.data.name.chars()
+                if state.settings.locale == Language::Japanese {
+                    self.stage.data.name_jp.chars()
+                } else {
+                    self.stage.data.name.chars()
+                }
             };
             let width = state.font.text_width(map_name.clone(), &state.constants);
 

--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::ops::{Deref, Range};
 use std::rc::Rc;
 
@@ -1966,7 +1967,10 @@ impl Scene for GameScene {
         self.text_boxes.draw(state, ctx, &self.frame)?;
 
         if self.skip_counter > 1 {
-            let text = format!("Hold {:?} to skip the cutscene", state.settings.player1_key_map.inventory);
+            let text = state.tt(
+                "game.cutscene_skip",
+                HashMap::from([("key".to_owned(), format!("{:?}", state.settings.player1_key_map.inventory))]),
+            );
             let width = state.font.text_width(text.chars(), &state.constants);
             let pos_x = state.canvas_size.0 - width - 20.0;
             let pos_y = 0.0;

--- a/src/scene/jukebox_scene.rs
+++ b/src/scene/jukebox_scene.rs
@@ -32,6 +32,7 @@ impl JukeboxScene {
             map: Map { width: 0, height: 0, tiles: vec![], attrib: [0; 0x100], tile_size: TileSize::Tile16x16 },
             data: StageData {
                 name: "".to_string(),
+                name_jp: "".to_string(),
                 map: "".to_string(),
                 boss_no: 0,
                 tileset: Tileset { name: "0".to_string() },

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -196,10 +196,12 @@ impl Scene for TitleScene {
         self.controller.update(state, ctx)?;
         self.controller.update_trigger();
 
+        self.main_menu.update_width(state);
         self.main_menu.update_height();
         self.main_menu.x = ((state.canvas_size.0 - self.main_menu.width as f32) / 2.0).floor() as isize;
         self.main_menu.y = ((state.canvas_size.1 + 70.0 - self.main_menu.height as f32) / 2.0).floor() as isize;
 
+        self.challenges_menu.update_width(state);
         self.challenges_menu.update_height();
         self.challenges_menu.x = ((state.canvas_size.0 - self.challenges_menu.width as f32) / 2.0).floor() as isize;
         self.challenges_menu.y =
@@ -320,6 +322,7 @@ impl Scene for TitleScene {
             },
         }
 
+        self.confirm_menu.update_width(state);
         self.confirm_menu.update_height();
         self.confirm_menu.x = ((state.canvas_size.0 - self.confirm_menu.width as f32) / 2.0).floor() as isize;
         self.confirm_menu.y = ((state.canvas_size.1 + 30.0 - self.confirm_menu.height as f32) / 2.0).floor() as isize;

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -49,6 +49,7 @@ impl TitleScene {
             map: Map { width: 0, height: 0, tiles: vec![], attrib: [0; 0x100], tile_size: TileSize::Tile16x16 },
             data: StageData {
                 name: "".to_string(),
+                name_jp: "".to_string(),
                 map: "".to_string(),
                 boss_no: 0,
                 tileset: Tileset { name: "0".to_string() },

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -123,6 +123,11 @@ impl TitleScene {
         }
         Ok(())
     }
+
+    pub fn open_settings_menu(&mut self) -> GameResult {
+        self.current_menu = CurrentMenu::OptionMenu;
+        Ok(())
+    }
 }
 
 static COPYRIGHT_PIXEL: &str = "2004.12  Studio Pixel"; // Freeware
@@ -138,24 +143,24 @@ impl Scene for TitleScene {
         self.controller.add(state.settings.create_player1_controller());
         self.controller.add(state.settings.create_player2_controller());
 
-        self.main_menu.push_entry(MenuEntry::Active("Start Game".to_string()));
+        self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.start")));
         if !state.mod_list.mods.is_empty() {
-            self.main_menu.push_entry(MenuEntry::Active("Challenges".to_string()));
+            self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.challenges")));
         } else {
             self.main_menu.push_entry(MenuEntry::Hidden);
         }
-        self.main_menu.push_entry(MenuEntry::Active("Options".to_string()));
+        self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.options")));
         if cfg!(feature = "editor") {
-            self.main_menu.push_entry(MenuEntry::Active("Editor".to_string()));
+            self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.editor")));
         } else {
             self.main_menu.push_entry(MenuEntry::Hidden);
         }
         if state.constants.is_switch {
-            self.main_menu.push_entry(MenuEntry::Active("Jukebox".to_string()));
+            self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.jukebox")));
         } else {
             self.main_menu.push_entry(MenuEntry::Hidden);
         }
-        self.main_menu.push_entry(MenuEntry::Active("Quit".to_string()));
+        self.main_menu.push_entry(MenuEntry::Active(state.t("menus.main_menu.quit")));
 
         self.settings_menu.init(state, ctx)?;
 
@@ -164,12 +169,12 @@ impl Scene for TitleScene {
         for mod_info in state.mod_list.mods.iter() {
             self.challenges_menu.push_entry(MenuEntry::Active(mod_info.name.clone()));
         }
-        self.challenges_menu.push_entry(MenuEntry::Active("< Back".to_string()));
+        self.challenges_menu.push_entry(MenuEntry::Active(state.t("common.back")));
 
         self.confirm_menu.push_entry(MenuEntry::Disabled("".to_owned()));
-        self.confirm_menu.push_entry(MenuEntry::Active("Start".to_owned()));
-        self.confirm_menu.push_entry(MenuEntry::Disabled("No Replay".to_owned()));
-        self.confirm_menu.push_entry(MenuEntry::Active("< Back".to_owned()));
+        self.confirm_menu.push_entry(MenuEntry::Active(state.t("menus.challenge_menu.start")));
+        self.confirm_menu.push_entry(MenuEntry::Disabled(state.t("menus.challenge_menu.no_replay")));
+        self.confirm_menu.push_entry(MenuEntry::Active(state.t("common.back")));
         self.confirm_menu.selected = 1;
 
         self.controller.update(state, ctx)?;
@@ -277,9 +282,9 @@ impl Scene for TitleScene {
                                     (state.font.text_width(mod_name.chars(), &state.constants).max(50.0) + 32.0) as u16;
                                 self.confirm_menu.entries[0] = MenuEntry::Disabled(mod_name);
                                 self.confirm_menu.entries[2] = if state.has_replay_data(ctx) {
-                                    MenuEntry::Active("Replay Best".to_owned())
+                                    MenuEntry::Active(state.t("menus.challenge_menu.replay_best"))
                                 } else {
-                                    MenuEntry::Disabled("No Replay".to_owned())
+                                    MenuEntry::Disabled(state.t("menus.challenge_menu.no_replay"))
                                 };
                                 self.nikumaru_rec.load_counter(state, ctx)?;
                                 self.current_menu = CurrentMenu::ChallengeConfirmMenu;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -55,7 +55,7 @@ fn default_true() -> bool {
 
 #[inline(always)]
 fn current_version() -> u32 {
-    6
+    7
 }
 
 #[inline(always)]
@@ -76,6 +76,11 @@ fn default_speed() -> f64 {
 #[inline(always)]
 fn default_vol() -> f32 {
     1.0
+}
+
+#[inline(always)]
+fn default_locale() -> Language {
+    Language::English
 }
 
 impl Settings {
@@ -113,6 +118,11 @@ impl Settings {
             self.version = 6;
             self.player1_key_map.strafe = ScanCode::LShift;
             self.player2_key_map.strafe = ScanCode::RShift;
+        }
+
+        if self.version == 6 {
+            self.version = 7;
+            self.locale = default_locale();
         }
 
         if self.version != initial_version {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use crate::input::keyboard_player_controller::KeyboardController;
 use crate::input::player_controller::PlayerController;
 use crate::input::touch_player_controller::TouchPlayerController;
 use crate::player::TargetPlayer;
-use crate::shared_game_state::TimingMode;
+use crate::shared_game_state::{Language, TimingMode};
 use crate::sound::InterpolationMode;
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -46,6 +46,7 @@ pub struct Settings {
     #[serde(skip)]
     pub debug_outlines: bool,
     pub fps_counter: bool,
+    pub locale: Language,
 }
 
 fn default_true() -> bool {
@@ -164,6 +165,7 @@ impl Default for Settings {
             infinite_booster: false,
             debug_outlines: false,
             fps_counter: false,
+            locale: Language::English,
         }
     }
 }

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -409,7 +409,7 @@ impl SharedGameState {
         self.constants.load_csplus_tables(ctx)?;
         self.constants.load_animated_faces(ctx)?;
         self.constants.load_texture_size_hints(ctx)?;
-        let stages = StageData::load_stage_table(ctx, &self.constants.base_paths)?;
+        let stages = StageData::load_stage_table(ctx, &self.constants.base_paths, self.constants.is_switch)?;
         self.stages = stages;
 
         let npc_tbl = filesystem::open_find(ctx, &self.constants.base_paths, "/npc.tbl")?;

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -199,6 +199,7 @@ pub struct PxPackStageData {
 #[derive(Debug)]
 pub struct StageData {
     pub name: String,
+    pub name_jp: String,
     pub map: String,
     pub boss_no: u8,
     pub tileset: Tileset,
@@ -214,6 +215,7 @@ impl Clone for StageData {
     fn clone(&self) -> Self {
         StageData {
             name: self.name.clone(),
+            name_jp: self.name_jp.clone(),
             map: self.map.clone(),
             boss_no: self.boss_no,
             tileset: self.tileset.clone(),
@@ -274,8 +276,16 @@ fn from_shift_jis(s: &[u8]) -> String {
     chars.iter().collect()
 }
 
+fn from_csplus_stagetbl(s: &[u8], is_switch: bool) -> String {
+    if is_switch {
+        from_utf8(s).unwrap_or("").trim_matches('\0').to_string()
+    } else {
+        from_shift_jis(s)
+    }
+}
+
 impl StageData {
-    pub fn load_stage_table(ctx: &mut Context, roots: &Vec<String>) -> GameResult<Vec<Self>> {
+    pub fn load_stage_table(ctx: &mut Context, roots: &Vec<String>, is_switch: bool) -> GameResult<Vec<Self>> {
         let stage_tbl_path = "/stage.tbl";
         let stage_sect_path = "/stage.sect";
         let mrmap_bin_path = "/mrmap.bin";
@@ -316,15 +326,17 @@ impl StageData {
                         f.read_exact(&mut name_jap_buf)?;
                         f.read_exact(&mut name_buf)?;
 
-                        let tileset = from_shift_jis(&ts_buf[0..zero_index(&ts_buf)]);
-                        let map = from_shift_jis(&map_buf[0..zero_index(&map_buf)]);
-                        let background = from_shift_jis(&back_buf[0..zero_index(&back_buf)]);
-                        let npc1 = from_shift_jis(&npc1_buf[0..zero_index(&npc1_buf)]);
-                        let npc2 = from_shift_jis(&npc2_buf[0..zero_index(&npc2_buf)]);
-                        let name = from_shift_jis(&name_buf[0..zero_index(&name_buf)]);
+                        let tileset = from_csplus_stagetbl(&ts_buf[0..zero_index(&ts_buf)], is_switch);
+                        let map = from_csplus_stagetbl(&map_buf[0..zero_index(&map_buf)], is_switch);
+                        let background = from_csplus_stagetbl(&back_buf[0..zero_index(&back_buf)], is_switch);
+                        let npc1 = from_csplus_stagetbl(&npc1_buf[0..zero_index(&npc1_buf)], is_switch);
+                        let npc2 = from_csplus_stagetbl(&npc2_buf[0..zero_index(&npc2_buf)], is_switch);
+                        let name = from_csplus_stagetbl(&name_buf[0..zero_index(&name_buf)], is_switch);
+                        let name_jp = from_csplus_stagetbl(&name_jap_buf[0..zero_index(&name_jap_buf)], is_switch);
 
                         let stage = StageData {
                             name: name.clone(),
+                            name_jp: name_jp.clone(),
                             map: map.clone(),
                             boss_no,
                             tileset: Tileset::new(&tileset),
@@ -389,6 +401,7 @@ impl StageData {
 
                 let stage = StageData {
                     name: name.clone(),
+                    name_jp: name.clone(),
                     map: map.clone(),
                     boss_no,
                     tileset: Tileset::new(&tileset),
@@ -447,6 +460,7 @@ impl StageData {
 
                 let stage = StageData {
                     name: name.clone(),
+                    name_jp: name.clone(),
                     map: map.clone(),
                     boss_no,
                     tileset: Tileset::new(&tileset),
@@ -503,6 +517,7 @@ impl StageData {
 
                 let stage = StageData {
                     name: name.clone(),
+                    name_jp: name.clone(),
                     map: map.clone(),
                     boss_no,
                     tileset: Tileset::new(NXENGINE_TILESETS.get(tileset_id).unwrap_or(&"0")),


### PR DESCRIPTION
This PR adds support for:

- JSON-based UI localization
- Japanese UI translation
- Loading the game in different languages
- Japanese stage names
- Dynamic menu widths to prevent text overflow

Notes: the CS+ Japanese font is messed up, until we figure out what's going on with it, the engine will fallback to the builtin font when the Japanese language is selected.