### PR TITLE
add challenge unlocking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod macros;
 mod map;
 mod menu;
 mod mod_list;
+mod mod_requirements;
 #[cfg(feature = "netplay")]
 mod netplay;
 mod npc;

--- a/src/mod_list.rs
+++ b/src/mod_list.rs
@@ -4,6 +4,7 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 use crate::framework::filesystem;
+use crate::mod_requirements::ModRequirements;
 use crate::{Context, GameResult};
 
 #[derive(Debug)]
@@ -15,6 +16,18 @@ pub struct ModInfo {
     pub path: String,
     pub name: String,
     pub description: String,
+}
+
+impl ModInfo {
+    pub fn satisfies_requirement(&self, mod_requirements: &ModRequirements) -> bool {
+        match self.requirement {
+            Requirement::Unlocked => true,
+            Requirement::Locked => false,
+            Requirement::RequireHell => mod_requirements.beat_hell,
+            Requirement::RequireItem(item_id) => mod_requirements.has_item(item_id),
+            Requirement::RequireWeapon(weapon_id) => mod_requirements.has_weapon(weapon_id),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -85,7 +98,6 @@ impl ModList {
                                 } else if c == '-' {
                                     requirement = Requirement::Locked;
                                 } else if c == 'I' {
-                                    chars.next();
                                     let mut item_id = String::new();
                                     for c in &mut chars {
                                         if c == ' ' {
@@ -96,7 +108,6 @@ impl ModList {
                                     }
                                     requirement = Requirement::RequireItem(item_id.parse().unwrap_or(0));
                                 } else if c == 'A' {
-                                    chars.next();
                                     let mut weapon_id = String::new();
                                     for c in &mut chars {
                                         if c == ' ' {

--- a/src/mod_requirements.rs
+++ b/src/mod_requirements.rs
@@ -1,0 +1,116 @@
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+
+use crate::framework::context::Context;
+use crate::framework::error::GameResult;
+use crate::framework::filesystem;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ModRequirements {
+    #[serde(default = "current_version")]
+    pub version: u32,
+
+    pub beat_hell: bool,
+    pub weapons: [u16; 8],
+    pub items: [u16; 32],
+}
+
+#[inline(always)]
+fn current_version() -> u32 {
+    1
+}
+
+impl ModRequirements {
+    pub fn load(ctx: &Context) -> GameResult<ModRequirements> {
+        let mut version = current_version();
+        let mut beat_hell: bool = false;
+        let mut weapons = [0u16; 8];
+        let mut items = [0u16; 32];
+
+        if let Ok(mut file) = filesystem::user_open(ctx, "/mod.req") {
+            version = file.read_u32::<LE>()?;
+            beat_hell = file.read_u16::<LE>()? != 0;
+
+            for weapon in &mut weapons {
+                *weapon = file.read_u16::<LE>()?;
+            }
+
+            for item in &mut items {
+                *item = file.read_u16::<LE>()?;
+            }
+        }
+
+        let mod_requirements = ModRequirements { version, beat_hell, weapons, items };
+
+        Ok(mod_requirements.upgrade())
+    }
+
+    fn upgrade(mut self) -> Self {
+        self
+    }
+
+    pub fn save(&self, ctx: &Context) -> GameResult {
+        let mut file = filesystem::user_create(ctx, "/mod.req")?;
+        file.write_u32::<LE>(self.version)?;
+        file.write_u16::<LE>(self.beat_hell as u16)?;
+
+        for weapon in &self.weapons {
+            file.write_u16::<LE>(*weapon)?;
+        }
+
+        for item in &self.items {
+            file.write_u16::<LE>(*item)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn append_weapon(&mut self, ctx: &Context, weapon_id: u16) -> GameResult {
+        for i in 0..self.weapons.len() {
+            if self.weapons[i] == weapon_id {
+                return Ok(());
+            }
+
+            if self.weapons[i] == 0 {
+                self.weapons[i] = weapon_id;
+                break;
+            }
+        }
+
+        self.save(ctx)
+    }
+
+    pub fn append_item(&mut self, ctx: &Context, item_id: u16) -> GameResult {
+        for i in 0..self.items.len() {
+            if self.items[i] == item_id {
+                return Ok(());
+            }
+
+            if self.items[i] == 0 {
+                self.items[i] = item_id;
+                break;
+            }
+        }
+
+        self.save(ctx)
+    }
+
+    pub fn has_weapon(&self, weapon_id: u16) -> bool {
+        for weapon in &self.weapons {
+            if *weapon == weapon_id {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn has_item(&self, item_id: u16) -> bool {
+        for item in &self.items {
+            if *item == item_id {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -62,6 +62,8 @@ impl GameProfile {
             if weapon.weapon_id == 0 {
                 continue;
             }
+
+            state.mod_requirements.append_weapon(ctx, weapon.weapon_id as u16);
             let weapon_type: Option<WeaponType> = FromPrimitive::from_u8(weapon.weapon_id as u8);
 
             if let Some(wtype) = weapon_type {
@@ -81,6 +83,8 @@ impl GameProfile {
 
         for item in self.items.iter().copied() {
             let item_id = item as u16;
+            state.mod_requirements.append_item(ctx, item_id);
+
             let amount = (item >> 16) as u16;
             if item_id == 0 {
                 break;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -63,7 +63,7 @@ impl GameProfile {
                 continue;
             }
 
-            state.mod_requirements.append_weapon(ctx, weapon.weapon_id as u16);
+            let _ = state.mod_requirements.append_weapon(ctx, weapon.weapon_id as u16);
             let weapon_type: Option<WeaponType> = FromPrimitive::from_u8(weapon.weapon_id as u8);
 
             if let Some(wtype) = weapon_type {
@@ -83,7 +83,7 @@ impl GameProfile {
 
         for item in self.items.iter().copied() {
             let item_id = item as u16;
-            state.mod_requirements.append_item(ctx, item_id);
+            let _ = state.mod_requirements.append_item(ctx, item_id);
 
             let amount = (item >> 16) as u16;
             if item_id == 0 {

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -171,10 +171,23 @@ impl Scene for TitleScene {
 
         self.save_select_menu.init(state, ctx)?;
 
+        let mut selected: usize = 0;
+        let mut mutate_selection = true;
+
         for mod_info in state.mod_list.mods.iter() {
-            self.challenges_menu.push_entry(MenuEntry::Active(mod_info.name.clone()));
+            if mod_info.satisfies_requirement(&state.mod_requirements) {
+                self.challenges_menu.push_entry(MenuEntry::Active(mod_info.name.clone()));
+                mutate_selection = false;
+            } else {
+                self.challenges_menu.push_entry(MenuEntry::Disabled("???".to_owned()));
+
+                if mutate_selection {
+                    selected += 1;
+                }
+            }
         }
         self.challenges_menu.push_entry(MenuEntry::Active(state.t("common.back")));
+        self.challenges_menu.selected = selected;
 
         self.confirm_menu.push_entry(MenuEntry::Disabled("".to_owned()));
         self.confirm_menu.push_entry(MenuEntry::Active(state.t("menus.challenge_menu.start")));

--- a/src/scripting/tsc/text_script.rs
+++ b/src/scripting/tsc/text_script.rs
@@ -567,6 +567,9 @@ impl TextScriptVM {
                         } else if tick == 750 {
                             tick = 900;
                         }
+
+                        state.mod_requirements.beat_hell = true;
+                        state.mod_requirements.save(ctx)?;
                     } else {
                         pos_y += 0x33;
                     }
@@ -1485,10 +1488,12 @@ impl TextScriptVM {
 
                 if !game_scene.inventory_player1.has_item(item_id) {
                     game_scene.inventory_player1.add_item(item_id);
+                    state.mod_requirements.append_item(ctx, item_id)?;
                 }
 
                 if !game_scene.inventory_player2.has_item(item_id) {
                     game_scene.inventory_player2.add_item(item_id);
+                    state.mod_requirements.append_item(ctx, item_id)?;
                 }
 
                 exec_state = TextScriptExecutionState::Running(event, cursor.position() as u32);
@@ -1499,10 +1504,12 @@ impl TextScriptVM {
 
                 if game_scene.inventory_player1.has_item_amount(item_id, Ordering::Less, amount) {
                     game_scene.inventory_player1.add_item(item_id);
+                    state.mod_requirements.append_item(ctx, item_id)?;
                 }
 
                 if game_scene.inventory_player2.has_item_amount(item_id, Ordering::Less, amount) {
                     game_scene.inventory_player2.add_item(item_id);
+                    state.mod_requirements.append_item(ctx, item_id)?;
                 }
 
                 exec_state = TextScriptExecutionState::Running(event, cursor.position() as u32);
@@ -1525,6 +1532,7 @@ impl TextScriptVM {
                 if let Some(wtype) = weapon_type {
                     game_scene.inventory_player1.add_weapon(wtype, max_ammo);
                     game_scene.inventory_player2.add_weapon(wtype, max_ammo);
+                    state.mod_requirements.append_weapon(ctx, weapon_id as u16)?;
                 }
 
                 exec_state = TextScriptExecutionState::Running(event, cursor.position() as u32);

--- a/src/scripting/tsc/text_script.rs
+++ b/src/scripting/tsc/text_script.rs
@@ -567,9 +567,6 @@ impl TextScriptVM {
                         } else if tick == 750 {
                             tick = 900;
                         }
-
-                        state.mod_requirements.beat_hell = true;
-                        state.mod_requirements.save(ctx)?;
                     } else {
                         pos_y += 0x33;
                     }
@@ -1688,6 +1685,11 @@ impl TextScriptVM {
             }
             TSCOpCode::XX1 => {
                 let mode = read_cur_varint(&mut cursor)?;
+
+                if mode != 0 && !state.mod_requirements.beat_hell {
+                    state.mod_requirements.beat_hell = true;
+                    state.mod_requirements.save(ctx)?;
+                }
 
                 exec_state = TextScriptExecutionState::FallingIsland(
                     event,

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -21,6 +21,7 @@ use crate::hooks::init_hooks;
 use crate::i18n::Locale;
 use crate::input::touch_controls::TouchControls;
 use crate::mod_list::ModList;
+use crate::mod_requirements::ModRequirements;
 use crate::npc::NPCTable;
 use crate::profile::GameProfile;
 use crate::rng::XorShift;
@@ -265,6 +266,7 @@ pub struct SharedGameState {
     pub save_slot: usize,
     pub difficulty: GameDifficulty,
     pub replay_state: ReplayState,
+    pub mod_requirements: ModRequirements,
     pub shutdown: bool,
 }
 
@@ -273,6 +275,7 @@ impl SharedGameState {
         let mut constants = EngineConstants::defaults();
         let sound_manager = SoundManager::new(ctx)?;
         let settings = Settings::load(ctx)?;
+        let mod_requirements = ModRequirements::load(ctx)?;
 
         constants.load_locales(ctx)?;
 
@@ -389,6 +392,7 @@ impl SharedGameState {
             save_slot: 1,
             difficulty: GameDifficulty::Normal,
             replay_state: ReplayState::None,
+            mod_requirements,
             shutdown: false,
         })
     }


### PR DESCRIPTION
Challenges can be unlocked now based on their requirements.

- This data will persist in a ~~binary file called `mod.req`~~ JSON file called `mod_req.json`, so even if you delete your save files, the challenges will remain unlocked (like on CS+Switch)
- Fixed challenge data parser reading the wrong item/weapon ID requirement (it was offset by 1 char)
- Item and weapon requirements will be imported from save files but only if you load them up
- Item requirements will be added on each `<IT+` call\*
- Weapon requirements will be added on each `<AM+` call\*
- Hell requirement will be enabled once `<XX1` is called and while getting the best ending\*
- ~~`mod.req`~~ `mod_req.json` files are versioned in a way that's similar to the settings file

\*) Every time you get a new item/weapon or beat hell for the first time, the ~~`mod.req`~~ `mod_req.json` file will be saved.