### PR TITLE
codesign macOS builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -108,6 +108,7 @@ for:
       - cp LICENSE ./release/LICENSE
       - cp -a target/$target/release/bundle/osx/doukutsu-rs.app ./release/doukutsu-rs.app
       - cd release
+      - codesign -s - -f ./doukutsu-rs.app/Contents/MacOS/doukutsu-rs
       - 7z a ../doukutsu-rs_$target_name.zip *
       - appveyor PushArtifact ../doukutsu-rs_$target_name.zip
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ in [Rust](https://www.rust-lang.org/).
   - [macOS (Apple M1, 11.0+)](https://ci.appveyor.com/api/projects/alula/doukutsu-rs/artifacts/doukutsu-rs_mac-m1.zip?branch=master&job=mac-arm64)
   - [Linux (x86_64)](https://ci.appveyor.com/api/projects/alula/doukutsu-rs/artifacts/doukutsu-rs_linux.zip?branch=master&job=linux-x64)
   
-  **macOS note:** If you get a `"doukutsu-rs.app" is damaged and can't be opened` message run the following command in Terminal (it's caused by the fact d-rs isn't notarized):
-  
-  `sudo xattr -rds com.apple.quarantine /path/to/doukutsu-rs.app`
-  
-  Then just provide your user password if prompted (there's no feedback, just type it in and hit Enter) and try to run doukutsu-rs again.
+  **macOS note:** If you get a `"doukutsu-rs" can't be opened` message, right-click doukutsu-rs.app and click open.
   
 - [Get stable/beta builds from GitHub Releases](https://github.com/doukutsu-rs/doukutsu-rs/releases) (executables only,
   no data files bundled, see below for instructions)


### PR DESCRIPTION
- Fixed macOS quarantine problem by codesigning the doukutsu-rs binary (inside of doukutsu-rs.app)
- Updated the macOS note in the README accordingly to tell users how to run the unverified binary.