### PR TITLE
add window mode toggle and save setting

### DIFF
--- a/src/builtin/locale/en.json
+++ b/src/builtin/locale/en.json
@@ -51,6 +51,11 @@
     "options_menu": {
       "graphics": "Graphics...",
       "graphics_menu": {
+        "window_mode": {
+          "entry": "Screen mode:",
+          "windowed": "Windowed",
+          "fullscreen": "Fullscreen"
+        },
         "lighting_effects": "Lighting effects:",
         "weapon_light_cone": "Weapon light cone:",
         "motion_interpolation": "Motion interpolation:",

--- a/src/builtin/locale/en.json
+++ b/src/builtin/locale/en.json
@@ -52,7 +52,7 @@
       "graphics": "Graphics...",
       "graphics_menu": {
         "window_mode": {
-          "entry": "Screen mode:",
+          "entry": "Display mode:",
           "windowed": "Windowed",
           "fullscreen": "Fullscreen"
         },

--- a/src/builtin/locale/jp.json
+++ b/src/builtin/locale/jp.json
@@ -45,6 +45,11 @@
     "options_menu": {
       "graphics": "グラフィック",
       "graphics_menu": {
+        "window_mode": {
+          "entry": "画面表示：",
+          "windowed": "ウィンドウ",
+          "fullscreen": "フルスクリーン"
+        },
         "lighting_effects": "ライティング効果：",
         "weapon_light_cone": "兵器のライトコーン：",
         "motion_interpolation": "モーション補間：",

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -9,7 +9,7 @@ use crate::input::combined_menu_controller::CombinedMenuController;
 use crate::menu::MenuEntry;
 use crate::menu::{Menu, MenuSelectionResult};
 use crate::scene::title_scene::TitleScene;
-use crate::shared_game_state::{Language, SharedGameState, TimingMode};
+use crate::shared_game_state::{Language, SharedGameState, TimingMode, WindowMode};
 use crate::sound::InterpolationMode;
 use crate::{graphics, VSyncMode};
 
@@ -48,6 +48,23 @@ impl SettingsMenu {
     }
 
     pub fn init(&mut self, state: &mut SharedGameState, ctx: &mut Context) -> GameResult {
+        #[cfg(not(target_os = "android"))]
+        self.graphics.push_entry(MenuEntry::Options(
+            state.t("menus.options_menu.graphics_menu.window_mode.entry"),
+            state.settings.window_mode as usize,
+            vec![
+                state.t("menus.options_menu.graphics_menu.window_mode.windowed"),
+                state.t("menus.options_menu.graphics_menu.window_mode.fullscreen"),
+            ],
+        ));
+
+        #[cfg(target_os = "android")]
+        {
+            let entry_text = state.t("menus.options_menu.graphics_menu.window_mode.entry") + " N/A";
+            self.graphics.push_entry(MenuEntry::Disabled(entry_text));
+            self.graphics.selected += 1;
+        }
+
         self.graphics.push_entry(MenuEntry::DescriptiveOptions(
             state.t("menus.options_menu.graphics_menu.vsync_mode.entry"),
             state.settings.vsync_mode as usize,
@@ -282,7 +299,23 @@ impl SettingsMenu {
                 _ => (),
             },
             CurrentMenu::GraphicsMenu => match self.graphics.tick(controller, state) {
-                MenuSelectionResult::Selected(0, toggle) | MenuSelectionResult::Right(0, toggle, _) => {
+                MenuSelectionResult::Selected(0, toggle)
+                | MenuSelectionResult::Right(0, toggle, _)
+                | MenuSelectionResult::Left(0, toggle, _) => {
+                    if let MenuEntry::Options(_, value, _) = toggle {
+                        let (new_mode, new_value) = match *value {
+                            0 => (WindowMode::Fullscreen, 1),
+                            1 => (WindowMode::Windowed, 0),
+                            _ => unreachable!(),
+                        };
+
+                        *value = new_value;
+                        state.settings.window_mode = new_mode;
+
+                        let _ = state.settings.save(ctx);
+                    }
+                }
+                MenuSelectionResult::Selected(1, toggle) | MenuSelectionResult::Right(1, toggle, _) => {
                     if let MenuEntry::DescriptiveOptions(_, value, _, _) = toggle {
                         let (new_mode, new_value) = match *value {
                             0 => (VSyncMode::VSync, 1),
@@ -299,7 +332,7 @@ impl SettingsMenu {
                         let _ = state.settings.save(ctx);
                     }
                 }
-                MenuSelectionResult::Left(0, toggle, _) => {
+                MenuSelectionResult::Left(1, toggle, _) => {
                     if let MenuEntry::DescriptiveOptions(_, value, _, _) = toggle {
                         let (new_mode, new_value) = match *value {
                             0 => (VSyncMode::VRRTickSync3x, 4),
@@ -316,7 +349,7 @@ impl SettingsMenu {
                         let _ = state.settings.save(ctx);
                     }
                 }
-                MenuSelectionResult::Selected(1, toggle) => {
+                MenuSelectionResult::Selected(2, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.shader_effects = !state.settings.shader_effects;
                         let _ = state.settings.save(ctx);
@@ -324,7 +357,7 @@ impl SettingsMenu {
                         *value = state.settings.shader_effects;
                     }
                 }
-                MenuSelectionResult::Selected(2, toggle) => {
+                MenuSelectionResult::Selected(3, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.light_cone = !state.settings.light_cone;
                         let _ = state.settings.save(ctx);
@@ -332,7 +365,7 @@ impl SettingsMenu {
                         *value = state.settings.light_cone;
                     }
                 }
-                MenuSelectionResult::Selected(3, toggle) => {
+                MenuSelectionResult::Selected(4, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.motion_interpolation = !state.settings.motion_interpolation;
                         let _ = state.settings.save(ctx);
@@ -340,7 +373,7 @@ impl SettingsMenu {
                         *value = state.settings.motion_interpolation;
                     }
                 }
-                MenuSelectionResult::Selected(4, toggle) => {
+                MenuSelectionResult::Selected(5, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.subpixel_coords = !state.settings.subpixel_coords;
                         let _ = state.settings.save(ctx);
@@ -348,7 +381,7 @@ impl SettingsMenu {
                         *value = state.settings.subpixel_coords;
                     }
                 }
-                MenuSelectionResult::Selected(5, toggle) => {
+                MenuSelectionResult::Selected(6, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.original_textures = !state.settings.original_textures;
                         if self.on_title {
@@ -361,7 +394,7 @@ impl SettingsMenu {
                         *value = state.settings.original_textures;
                     }
                 }
-                MenuSelectionResult::Selected(6, toggle) => {
+                MenuSelectionResult::Selected(7, toggle) => {
                     if let MenuEntry::Toggle(_, value) = toggle {
                         state.settings.seasonal_textures = !state.settings.seasonal_textures;
                         state.reload_graphics();
@@ -370,7 +403,7 @@ impl SettingsMenu {
                         *value = state.settings.seasonal_textures;
                     }
                 }
-                MenuSelectionResult::Selected(8, _) | MenuSelectionResult::Canceled => {
+                MenuSelectionResult::Selected(9, _) | MenuSelectionResult::Canceled => {
                     self.current = CurrentMenu::MainMenu
                 }
                 _ => (),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use crate::input::keyboard_player_controller::KeyboardController;
 use crate::input::player_controller::PlayerController;
 use crate::input::touch_player_controller::TouchPlayerController;
 use crate::player::TargetPlayer;
-use crate::shared_game_state::{Language, TimingMode};
+use crate::shared_game_state::{Language, TimingMode, WindowMode};
 use crate::sound::InterpolationMode;
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -48,6 +48,8 @@ pub struct Settings {
     pub debug_outlines: bool,
     pub fps_counter: bool,
     pub locale: Language,
+    #[serde(default = "default_window_mode")]
+    pub window_mode: WindowMode,
     #[serde(default = "default_vsync")]
     pub vsync_mode: VSyncMode,
     pub debug_mode: bool,
@@ -61,12 +63,17 @@ fn default_true() -> bool {
 
 #[inline(always)]
 fn current_version() -> u32 {
-    9
+    10
 }
 
 #[inline(always)]
 fn default_timing() -> TimingMode {
     TimingMode::_50Hz
+}
+
+#[inline(always)]
+fn default_window_mode() -> WindowMode {
+    WindowMode::Windowed
 }
 
 #[inline(always)]
@@ -146,6 +153,11 @@ impl Settings {
             self.debug_mode = false;
         }
 
+        if self.version == 9 {
+            self.version = 10;
+            self.window_mode = default_window_mode();
+        }
+
         if self.version != initial_version {
             log::info!("Upgraded configuration file from version {} to {}.", initial_version, self.version);
         }
@@ -197,6 +209,7 @@ impl Default for Settings {
             debug_outlines: false,
             fps_counter: false,
             locale: Language::English,
+            window_mode: WindowMode::Windowed,
             vsync_mode: VSyncMode::VSync,
             debug_mode: false,
             noclip: false,

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -44,6 +44,29 @@ pub enum TimingMode {
     FrameSynchronized,
 }
 
+#[derive(PartialEq, Eq, Copy, Clone, serde::Serialize, serde::Deserialize)]
+pub enum WindowMode {
+    Windowed,
+    Fullscreen,
+}
+
+impl WindowMode {
+    #[cfg(feature = "backend-sdl")]
+    pub fn get_sdl2_fullscreen_type(&self) -> sdl2::video::FullscreenType {
+        match self {
+            WindowMode::Windowed => sdl2::video::FullscreenType::Off,
+            WindowMode::Fullscreen => sdl2::video::FullscreenType::Desktop,
+        }
+    }
+
+    pub fn should_display_mouse_cursor(&self) -> bool {
+        match self {
+            WindowMode::Windowed => true,
+            WindowMode::Fullscreen => false,
+        }
+    }
+}
+
 impl TimingMode {
     pub fn get_delta(self) -> usize {
         match self {


### PR DESCRIPTION
Makes windowed/fullscreen mode toggleable from the Settings > Graphics menu. It will also save the setting, so next time you open the game it will be whatever you've selected.

Note: I didn't make this a fullscreen on/off toggle just in case we want to add predefined resolutions at some point to this setting.

Alula might kill me for the way I implemented this, but as much as I tried to implement it properly, Rust didn't really like it. I was going to make this a method in the SDL event loop, but I can't really access the event loop from anywhere and saving it in the context struct would infuriate Rust and make everything more complicated.