### PR TITLE
Proper wiiware DEMO support

### DIFF
--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -1773,7 +1773,7 @@ impl EngineConstants {
         self.supports_og_textures = true;
         self.game.new_game_stage = 11;
         self.game.new_game_event = 302;
-        self.game.new_game_player_pos = (160, 76);
+        self.game.new_game_player_pos = (8, 6);
         self.title.logo_splash_rect = Rect { left: 224, top: 0, right: 320, bottom: 48 };
     }
 

--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -249,6 +249,7 @@ pub struct TextScriptConsts {
 pub struct TitleConsts {
     pub intro_text: String,
     pub logo_rect: Rect<u16>,
+    pub logo_splash_rect: Rect<u16>,
     pub menu_left_top: Rect<u16>,
     pub menu_right_top: Rect<u16>,
     pub menu_left_bottom: Rect<u16>,
@@ -270,6 +271,7 @@ impl Clone for TitleConsts {
         TitleConsts {
             intro_text: self.intro_text.clone(),
             logo_rect: self.logo_rect,
+            logo_splash_rect: self.logo_splash_rect,
             menu_left_top: self.menu_left_top,
             menu_right_top: self.menu_right_top,
             menu_left_bottom: self.menu_left_bottom,
@@ -1551,6 +1553,7 @@ impl EngineConstants {
             title: TitleConsts {
                 intro_text: "Studio Pixel presents".to_owned(),
                 logo_rect: Rect { left: 0, top: 0, right: 144, bottom: 40 },
+                logo_splash_rect: Rect { left: 0, top: 0, right: 0, bottom: 0 }, //Hidden so patches can display splash art / subtitle
                 menu_left_top: Rect { left: 0, top: 0, right: 8, bottom: 8 },
                 menu_right_top: Rect { left: 236, top: 0, right: 244, bottom: 8 },
                 menu_left_bottom: Rect { left: 0, top: 16, right: 8, bottom: 24 },
@@ -1700,7 +1703,7 @@ impl EngineConstants {
         self.tex_sizes.insert("Npc/NpcRegu".to_owned(), (320, 410));
         self.tex_sizes.insert("ui".to_owned(), (128, 32));
         self.textscript.reset_invicibility_on_any_script = false;
-        self.title.logo_rect = Rect { left: 0, top: 0, right: 214, bottom: 50 };
+        self.title.logo_rect = Rect { left: 0, top: 0, right: 216, bottom: 48 };
 
         self.title.menu_left_top = Rect { left: 0, top: 0, right: 4, bottom: 4 };
         self.title.menu_right_top = Rect { left: 12, top: 0, right: 16, bottom: 4 };
@@ -1771,6 +1774,7 @@ impl EngineConstants {
         self.game.new_game_stage = 11;
         self.game.new_game_event = 302;
         self.game.new_game_player_pos = (160, 76);
+        self.title.logo_splash_rect = Rect { left: 224, top: 0, right: 320, bottom: 48 };
     }
 
     pub fn rebuild_path_list(&mut self, mod_path: Option<String>, season: Season, settings: &Settings) {

--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -316,6 +316,7 @@ pub struct EngineConstants {
     pub base_paths: Vec<String>,
     pub is_cs_plus: bool,
     pub is_switch: bool,
+    pub is_demo: bool,
     pub supports_og_textures: bool,
     pub game: GameConsts,
     pub player: PlayerConsts,
@@ -348,6 +349,7 @@ impl Clone for EngineConstants {
             base_paths: self.base_paths.clone(),
             is_cs_plus: self.is_cs_plus,
             is_switch: self.is_switch,
+            is_demo: self.is_demo,
             supports_og_textures: self.supports_og_textures,
             game: self.game,
             player: self.player,
@@ -382,6 +384,7 @@ impl EngineConstants {
             base_paths: Vec::new(),
             is_cs_plus: false,
             is_switch: false,
+            is_demo: false,
             supports_og_textures: false,
             game: GameConsts {
                 intro_stage: 72,
@@ -1758,6 +1761,16 @@ impl EngineConstants {
         self.textscript.fade_ticks = 21;
         self.game.tile_offset_x = 3;
         self.game.new_game_player_pos = (13, 8);
+    }
+
+    pub fn apply_csdemo_patches(&mut self) {
+        log::info!("Applying Wiiware DEMO-specific Cave Story+ constants patches...");
+
+        self.is_demo = true;
+        self.supports_og_textures = true;
+        self.game.new_game_stage = 11;
+        self.game.new_game_event = 302;
+        self.game.new_game_player_pos = (160, 76);
     }
 
     pub fn rebuild_path_list(&mut self, mod_path: Option<String>, season: Season, settings: &Settings) {

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -442,7 +442,11 @@ impl Scene for TitleScene {
                 40.0,
                 &state.constants.title.logo_rect,
             );
-
+            batch.add_rect(
+                ((state.canvas_size.0 - state.constants.title.logo_splash_rect.width() as f32) / 2.0).floor() + 72.0,
+                88.0,
+                &state.constants.title.logo_splash_rect,
+            );
             batch.draw(ctx)?;
         } else {
             let window_title = match self.current_menu {

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -347,7 +347,9 @@ impl SharedGameState {
             constants.apply_csplus_nx_patches();
             constants.load_nx_stringtable(ctx)?;
         } else if filesystem::exists(ctx, "/base/ogph/SellScreen.bmp") {
-            error!("WiiWare DEMO data files detected. !UNSUPPORTED!"); //Missing credits.tsc and crashes due to missing Stage 13 (Start)
+            info!("WiiWare DEMO data files detected.");
+            constants.apply_csplus_patches(&mut sound_manager);
+            constants.apply_csdemo_patches();
         } else if filesystem::exists(ctx, "/base/strap_a_en.bmp") {
             info!("WiiWare data files detected."); //Missing Challenges and Remastered Soundtrack but identical to CS+ PC otherwise
             constants.apply_csplus_patches(&mut sound_manager);
@@ -524,11 +526,11 @@ impl SharedGameState {
 
         let substitution_rect_map = HashMap::from([('=', self.constants.textscript.textbox_item_marker_rect)]);
         self.textscript_vm.set_substitution_rect_map(substitution_rect_map);
-
-        let credit_tsc = filesystem::open_find(ctx, &self.constants.base_paths, "Credit.tsc")?;
-        let credit_script = CreditScript::load_from(credit_tsc, &self.constants)?;
-        self.creditscript_vm.set_script(credit_script);
-
+        /*
+               let credit_tsc = filesystem::open_find(ctx, &self.constants.base_paths, "Credit.tsc")?;
+               let credit_script = CreditScript::load_from(credit_tsc, &self.constants)?;
+               self.creditscript_vm.set_script(credit_script);
+        */
         self.texture_set.unload_all();
 
         self.sound_manager.load_custom_sound_effects(ctx, &self.constants.base_paths)?;

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -501,7 +501,10 @@ impl SharedGameState {
 
     pub fn reload_resources(&mut self, ctx: &mut Context) -> GameResult {
         self.constants.rebuild_path_list(self.mod_path.clone(), self.season, &self.settings);
-        self.constants.special_treatment_for_csplus_mods(self.mod_path.as_ref());
+        if !self.constants.is_demo {
+            //TODO find a more elegant way to handle this
+            self.constants.special_treatment_for_csplus_mods(self.mod_path.as_ref());
+        }
         self.constants.load_csplus_tables(ctx)?;
         self.constants.load_animated_faces(ctx)?;
         self.constants.load_texture_size_hints(ctx)?;

--- a/src/shared_game_state.rs
+++ b/src/shared_game_state.rs
@@ -526,11 +526,13 @@ impl SharedGameState {
 
         let substitution_rect_map = HashMap::from([('=', self.constants.textscript.textbox_item_marker_rect)]);
         self.textscript_vm.set_substitution_rect_map(substitution_rect_map);
-        /*
-               let credit_tsc = filesystem::open_find(ctx, &self.constants.base_paths, "Credit.tsc")?;
-               let credit_script = CreditScript::load_from(credit_tsc, &self.constants)?;
-               self.creditscript_vm.set_script(credit_script);
-        */
+
+        if filesystem::exists_find(ctx, &self.constants.base_paths, "Credit.tsc") {
+            let credit_tsc = filesystem::open_find(ctx, &self.constants.base_paths, "Credit.tsc")?;
+            let credit_script = CreditScript::load_from(credit_tsc, &self.constants)?;
+            self.creditscript_vm.set_script(credit_script);
+        }
+
         self.texture_set.unload_all();
 
         self.sound_manager.load_custom_sound_effects(ctx, &self.constants.base_paths)?;


### PR DESCRIPTION
Makes DEMO data fully playable.

- Set the correct starting Event and Stage
- Add splash rect for the DEMO graphic
- Fix CS+ data from tiling ogph title
- Credit.tsc is now optional (thanks joe)

![image](https://user-images.githubusercontent.com/53099651/183258145-285f1a1e-01dd-4260-8352-712c16470219.png)
