### PR TITLE
Fix changing BGM Interpolation setting with left and right keys

### DIFF
--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -680,6 +680,7 @@ impl SettingsMenu {
                             3 => (InterpolationMode::Polyphase, 4),
                             _ => (InterpolationMode::Nearest, 0),
                         };
+                        
                         *value = new_value;
                         state.settings.organya_interpolation = new_mode;
                         state.sound_manager.set_org_interpolation(new_mode);
@@ -691,9 +692,9 @@ impl SettingsMenu {
                         let (new_mode, new_value) = match *value {
                             0 => (InterpolationMode::Polyphase, 4),
                             1 => (InterpolationMode::Nearest, 0),
-                            2 => (InterpolationMode::,Linear, 1),
-                            3 => (InterpolationMode::,Cosine, 2),
-                            _ => (InterpolationMode::,Cubic, 3),
+                            2 => (InterpolationMode::Linear, 1),
+                            3 => (InterpolationMode::Cosine, 2),
+                            _ => (InterpolationMode::Cubic, 3),
                         };
 
                         *value = new_value;

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -670,7 +670,8 @@ impl SettingsMenu {
                         let _ = state.settings.save(ctx);
                     }
                 }
-                MenuSelectionResult::Selected(SoundMenuEntry::BGMInterpolation, toggle) => {
+                 MenuSelectionResult::Selected(SoundMenuEntry::BGMInterpolation, toggle) 
+                | MenuSelectionResult::Right(SoundMenuEntry::BGMInterpolation, toggle, _) => {
                     if let MenuEntry::DescriptiveOptions(_, value, _, _) = toggle {
                         let (new_mode, new_value) = match *value {
                             0 => (InterpolationMode::Linear, 1),
@@ -679,11 +680,25 @@ impl SettingsMenu {
                             3 => (InterpolationMode::Polyphase, 4),
                             _ => (InterpolationMode::Nearest, 0),
                         };
+                        *value = new_value;
+                        state.settings.organya_interpolation = new_mode;
+                        state.sound_manager.set_org_interpolation(new_mode);
+                        let _ = state.settings.save(ctx);
+                    }
+                }
+                MenuSelectionResult::Left(SoundMenuEntry::BGMInterpolation, toggle, _) => {
+                    if let MenuEntry::DescriptiveOptions(_, value, _, _) = toggle {
+                        let (new_mode, new_value) = match *value {
+                            0 => (InterpolationMode::Polyphase, 4),
+                            1 => (InterpolationMode::Nearest, 0),
+                            2 => (InterpolationMode::,Linear, 1),
+                            3 => (InterpolationMode::,Cosine, 2),
+                            _ => (InterpolationMode::,Cubic, 3),
+                        };
 
                         *value = new_value;
                         state.settings.organya_interpolation = new_mode;
                         state.sound_manager.set_org_interpolation(new_mode);
-
                         let _ = state.settings.save(ctx);
                     }
                 }


### PR DESCRIPTION
Very small fix but it's been bugging me for a while. Allows the use of the left and right arrows to change the BGM Interpolation setting. On previous builds trying to change it would cause the *bwip!* sound to play but the actual setting would not change.