### PR TITLE
Fix downward facing fans pointing upwards

### DIFF
--- a/src/npc/ai/misc.rs
+++ b/src/npc/ai/misc.rs
@@ -927,7 +927,7 @@ impl NPC {
         }
 
         if self.anim_counter == 0 {
-            self.anim_rect = state.constants.npc.n097_fan_up[self.anim_num as usize];
+            self.anim_rect = state.constants.npc.n099_fan_down[self.anim_num as usize];
         }
 
         Ok(())


### PR DESCRIPTION
Looks like it was just using the n097_fan_up animation instead of n099_fan down.