### PR TITLE
Map System Equip fix

### DIFF
--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -1531,7 +1531,7 @@ impl GameScene {
                     self.inventory_player1.current_item = 0;
                     state.textscript_vm.set_mode(ScriptMode::Inventory);
                     self.player1.cond.set_interacted(false);
-                } else if self.player1.controller.trigger_map() && self.inventory_player1.has_item(2) {
+                } else if self.player1.controller.trigger_map() && self.player1.equip.has_map() {
                     state.textscript_vm.state = TextScriptExecutionState::MapSystem;
                 }
             }


### PR DESCRIPTION
Changing map key enable from a hardcode to item 2 to the actual vanilla behavior of checking for equip flag. Tested in-game.

(Found because I have a mod that uses item 2 for something else).