### PR TITLE
Fix 'render_opengl' import when 'render-opengl' feature is disabled

### DIFF
--- a/src/framework/backend_sdl2.rs
+++ b/src/framework/backend_sdl2.rs
@@ -32,6 +32,7 @@ use crate::framework::filesystem;
 use crate::framework::gamepad::{Axis, Button, GamepadType};
 use crate::framework::graphics::BlendMode;
 use crate::framework::keyboard::ScanCode;
+#[cfg(feature = "render-opengl")]
 use crate::framework::render_opengl::{GLContext, OpenGLRenderer};
 use crate::framework::ui::init_imgui;
 use crate::game::shared_game_state::WindowMode;


### PR DESCRIPTION
Import `crate::framework::render_opengl` causes crash when feature `render-opengl` is disabled