### PR TITLE
Remove use of MakePortable enrty on unsupported targets

### DIFF
--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -1032,6 +1032,8 @@ impl SettingsMenu {
                         fs_container.open_game_directory()?;
                     }
                 }
+                
+                #[cfg(not(any(target_os = "android", target_os = "horizon")))]
                 MenuSelectionResult::Selected(AdvancedMenuEntry::MakePortable, _) => {
                     self.current = CurrentMenu::PortableMenu;
                 }


### PR DESCRIPTION
 `MakePortable` not supported on `android` and `horizon` targets