### PR TITLE
Remove useless files from output android build

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -66,11 +66,6 @@ android {
             excludes += "**/dummy.so"
         }
 
-        resources {
-            excludes += "kotlin/**"
-            excludes += "/META-INF/kotlinx_*"
-        }
-
     }
 }
 


### PR DESCRIPTION
Add autoremoving `dummy.so`(we can't not built it) <s>and `kotlin builtins`(kotlin is not used in any way in the current android port)</s>(may be used by one of dependencies) from an output `apk` during build