### PR TITLE
Skip appveyor builds for android and horizon

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,9 @@ version: "0.101.0-{build}-{branch}"
 skip_commits:
   files:
     - README.md
+    - app/*
+    - drsandroid/*
+    - drshorizon/*
 
 environment:
   global:


### PR DESCRIPTION
Builds for Android and Horizon aren't currently configured, so starting the build after changing these files is useless(maybe someone will fix this later)