### PR TITLE
Accuracy fixes for Sand Zone and Labyrinth

### DIFF
--- a/src/game/npc/ai/balrog.rs
+++ b/src/game/npc/ai/balrog.rs
@@ -452,9 +452,8 @@ impl NPC {
                     self.vel_y = -0x800;
                     self.npc_flags.set_ignore_solidity(true);
 
-                    for npc in npc_list.iter_alive().filter(|npc| npc.npc_type == 117 || npc.npc_type == 150) {
-                        npc.cond.set_alive(false)
-                    }
+                    npc_list.kill_npcs_by_type(150, false, state);
+                    npc_list.kill_npcs_by_type(117, false, state);
 
                     let mut npc = NPC::create(355, &state.npc_table);
                     npc.cond.set_alive(true);

--- a/src/game/npc/ai/misc.rs
+++ b/src/game/npc/ai/misc.rs
@@ -92,11 +92,8 @@ impl NPC {
     }
 
     pub(crate) fn tick_n013_forcefield(&mut self, state: &mut SharedGameState) -> GameResult {
-        self.anim_counter = (self.anim_counter + 1) % 2;
-        if self.anim_counter == 1 {
-            self.anim_num = (self.anim_num + 1) % 4;
-            self.anim_rect = state.constants.npc.n013_forcefield[self.anim_num as usize];
-        }
+        self.anim_num = (self.anim_num + 1) % 4;
+        self.anim_rect = state.constants.npc.n013_forcefield[self.anim_num as usize];
 
         Ok(())
     }

--- a/src/game/npc/boss/ballos.rs
+++ b/src/game/npc/boss/ballos.rs
@@ -1754,7 +1754,7 @@ impl BossNPC {
                     self.parts[0].action_counter = 0;
                     self.parts[0].vel_x = 0;
                     self.parts[0].vel_y = 0;
-                    npc_list.kill_npcs_by_type(339, true, state);
+                    npc_list.kill_npcs_by_type(339, false, state);
                 }
 
                 self.parts[0].y += (0x13E00 - self.parts[0].y) / 8;

--- a/src/game/npc/boss/core.rs
+++ b/src/game/npc/boss/core.rs
@@ -180,6 +180,10 @@ impl BossNPC {
                 self.parts[7].x = self.parts[0].x - 0x6000;
                 self.parts[7].y = self.parts[0].y + 0x4000;
 
+                for i in [2,3,6,7] {
+                    self.hurt_sound[i] = 54;
+                }
+
                 for part in &mut self.parts {
                     part.prev_x = part.x;
                     part.prev_y = part.y;

--- a/src/game/npc/boss/mod.rs
+++ b/src/game/npc/boss/mod.rs
@@ -81,6 +81,8 @@ impl GameEntity<([&mut Player; 2], &NPCList, &mut Stage, &BulletManager, &mut Fl
         ),
     ) -> GameResult {
         if !self.parts[0].cond.alive() {
+            // Kind of hacky but fixes Monster X's damage popup being stuck on screen
+            self.parts[0].popup.tick(state, ())?;
             return Ok(());
         }
 

--- a/src/game/npc/boss/omega.rs
+++ b/src/game/npc/boss/omega.rs
@@ -75,6 +75,7 @@ impl BossNPC {
                 self.parts[0].display_bounds =
                     Rect { left: 40 * 0x200, top: 40 * 0x200, right: 40 * 0x200, bottom: 0x2000 };
                 self.parts[0].hit_bounds = Rect { left: 0x1000, top: 24 * 0x200, right: 0x1000, bottom: 0x2000 };
+                self.hurt_sound[0] = 52;
 
                 self.parts[1].cond.set_alive(true);
                 self.parts[1].display_bounds =
@@ -100,6 +101,7 @@ impl BossNPC {
                 self.parts[4].display_bounds = self.parts[3].display_bounds;
                 self.parts[4].hit_bounds = self.parts[3].hit_bounds;
                 self.parts[4].npc_flags = self.parts[3].npc_flags;
+                self.parts[4].x = self.parts[0].x - 0x2000;
                 self.parts[4].y = self.parts[3].y;
                 self.parts[4].direction = Direction::Right;
                 self.hurt_sound[4] = 52;
@@ -166,7 +168,7 @@ impl BossNPC {
             }
             60 => {
                 self.parts[0].action_counter += 1;
-                if self.parts[0].action_counter % 3 == 0 && (20..80).contains(&self.parts[0].action_counter) {
+                if self.parts[0].action_counter % 3 == 0 && (21..80).contains(&self.parts[0].action_counter) {
                     let mut npc = NPC::create(48, &state.npc_table);
                     npc.cond.set_alive(true);
                     npc.x = self.parts[0].x;
@@ -195,6 +197,8 @@ impl BossNPC {
                     match self.parts[0].anim_num {
                         1 => self.parts[0].damage = 20,
                         0 => {
+                            state.sound_manager.stop_sfx(102);
+                            state.sound_manager.play_sfx(12);
                             self.parts[0].action_num = 80;
                             self.parts[0].action_counter = 0;
                             self.parts[0].npc_flags.set_shootable(false);
@@ -297,7 +301,7 @@ impl BossNPC {
 
                         state.sound_manager.play_sfx(12);
                         state.sound_manager.play_sfx(25);
-                        state.sound_manager.play_sfx(102);
+                        state.sound_manager.stop_sfx(102);
                     }
                     1 => {
                         self.parts[0].damage = 20;
@@ -427,13 +431,9 @@ impl BossNPC {
             self.parts[0].action_num = 150;
             self.parts[0].action_counter = 0;
             self.parts[0].damage = 0;
-            self.parts[5].damage = 5;
+            self.parts[5].damage = 0;
 
-            for npc in npc_list.iter_alive() {
-                if npc.npc_type == 48 {
-                    npc.cond.set_alive(false);
-                }
-            }
+            npc_list.kill_npcs_by_type(48, true, state);
         }
     }
 }

--- a/src/game/npc/utils.rs
+++ b/src/game/npc/utils.rs
@@ -266,13 +266,13 @@ impl NPCList {
 
                 match npc.size {
                     1 => {
-                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 3, state, &npc.rng);
+                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 4, state, &npc.rng);
                     }
                     2 => {
-                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 7, state, &npc.rng);
+                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 8, state, &npc.rng);
                     }
                     3 => {
-                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 12, state, &npc.rng);
+                        self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 16, state, &npc.rng);
                     }
                     _ => {}
                 };
@@ -363,6 +363,10 @@ impl NPCList {
             if npc.npc_type == npc_type {
                 npc.cond.set_alive(false);
                 state.set_flag(npc.flag_num as usize, true);
+
+                if let Some(table_entry) = state.npc_table.get_entry(npc.npc_type) {
+                    state.sound_manager.play_sfx(table_entry.death_sound);
+                }
 
                 match npc.size {
                     1 => self.create_death_smoke(npc.x, npc.y, npc.display_bounds.right as usize, 4, state, &npc.rng),

--- a/src/game/player/mod.rs
+++ b/src/game/player/mod.rs
@@ -262,19 +262,20 @@ impl Player {
             }
 
             if state.control_flags.control_enabled() {
-                let trigger_only_down = self.controller.trigger_down()
-                    && !self.controller.trigger_up()
-                    && !self.controller.trigger_left()
-                    && !self.controller.trigger_right()
-                    && !self.controller.trigger_shoot();
-
                 let only_down = self.controller.move_down()
                     && !self.controller.move_up()
                     && !self.controller.move_left()
                     && !self.controller.move_right()
-                    && !self.controller.shoot();
+                    && !self.controller.shoot()
+                    && !self.controller.jump()
+                    && !self.controller.prev_weapon()
+                    && !self.controller.next_weapon()
+                    && !self.controller.map()
+                    && !self.controller.inventory()
+                    && !self.controller.strafe();
+                    // Leaving the skip button unchecked as a "feature" :)
 
-                if trigger_only_down
+                if self.controller.trigger_down()
                     && only_down
                     && !self.cond.interacted()
                     && !state.control_flags.interactions_disabled()

--- a/src/game/weapon/bullet.rs
+++ b/src/game/weapon/bullet.rs
@@ -1953,8 +1953,8 @@ impl PhysicalEntity for Bullet {
                         let mut npc = NPC::create(4, &state.npc_table);
                         npc.cond.set_alive(true);
                         npc.direction = Direction::Left;
-                        npc.x = (x * 16 + 8) * 0x200;
-                        npc.y = (y * 16 + 8) * 0x200;
+                        npc.x = (x + ox) * tile_size;
+                        npc.y = (y + oy) * tile_size;
 
                         for _ in 0..4 {
                             npc.vel_x = npc.rng.range(-0x200..0x200) as i32;


### PR DESCRIPTION
Punting aside for now the question of what to do with the (nearly) duplicate `NPCList::kill_npcs_by_type` and `NPCList::remove_by_type` functions by simply fixing the inaccuracies in both functions :)