### PR TITLE
Make all CMPs generate the correct amount of smoke

### DIFF
--- a/src/game/npc/ai/balrog.rs
+++ b/src/game/npc/ai/balrog.rs
@@ -483,19 +483,22 @@ impl NPC {
                     npc.x = x as i32 * 0x2000;
                     npc.y = y as i32 * 0x2000;
 
-                    let _ = npc_list.spawn(0x100, npc.clone());
-                    let _ = npc_list.spawn(0x100, npc.clone());
+                    let _ = npc_list.spawn(0, npc.clone());
+                    let _ = npc_list.spawn(0, npc.clone());
+                    let _ = npc_list.spawn(0, npc.clone());
 
                     if x > 0 && stage.change_tile(x - 1, y, 0) {
                         npc.x = (x - 1) as i32 * 0x2000;
-                        let _ = npc_list.spawn(0x100, npc.clone());
-                        let _ = npc_list.spawn(0x100, npc.clone());
+                        let _ = npc_list.spawn(0, npc.clone());
+                        let _ = npc_list.spawn(0, npc.clone());
+                        let _ = npc_list.spawn(0, npc.clone());
                     }
 
                     if x < stage.map.width as usize && stage.change_tile(x + 1, y, 0) {
                         npc.x = (x + 1) as i32 * 0x2000;
-                        let _ = npc_list.spawn(0x100, npc.clone());
-                        let _ = npc_list.spawn(0x100, npc);
+                        let _ = npc_list.spawn(0, npc.clone());
+                        let _ = npc_list.spawn(0, npc.clone());
+                        let _ = npc_list.spawn(0, npc);
                     }
                 }
 

--- a/src/game/npc/ai/hell.rs
+++ b/src/game/npc/ai/hell.rs
@@ -813,12 +813,23 @@ impl NPC {
                         let x = (self.x / (state.tile_size.as_int() * 0x100)) as usize;
                         let y = (self.y / (state.tile_size.as_int() * 0x100)) as usize;
 
+                        let mut change_tile_with_smoke = |x, y| {
+                            if stage.change_tile(x, y, 0) {
+                                let mut npc = NPC::create(4, &state.npc_table);
+                                npc.cond.set_alive(true);
+                                npc.x = (x as i32) * state.tile_size.as_int() * 0x200;
+                                npc.y = (y as i32) * state.tile_size.as_int() * 0x200;
+                                let _ = npc_list.spawn(0, npc.clone());
+                                let _ = npc_list.spawn(0, npc.clone());
+                                let _ = npc_list.spawn(0, npc);
+                            }
+                        };
                         if self.direction == Direction::Left {
-                            stage.change_tile(x / 2, (y + 1) / 2, 0);
-                            stage.change_tile(x / 2, (y - 1) / 2, 0);
+                            change_tile_with_smoke(x / 2, (y + 1) / 2);
+                            change_tile_with_smoke(x / 2, (y - 1) / 2);
                         } else {
-                            stage.change_tile((x + 1) / 2, y / 2, 0);
-                            stage.change_tile((x - 1) / 2, y / 2, 0);
+                            change_tile_with_smoke((x + 1) / 2, y / 2);
+                            change_tile_with_smoke((x - 1) / 2, y / 2);
                         }
                     }
                     _ => (),
@@ -833,12 +844,20 @@ impl NPC {
         Ok(())
     }
 
-    pub(crate) fn tick_n330_rolling(&mut self, state: &mut SharedGameState, stage: &mut Stage) -> GameResult {
+    pub(crate) fn tick_n330_rolling(&mut self, state: &mut SharedGameState, npc_list: &NPCList, stage: &mut Stage) -> GameResult {
         match self.action_num {
             0 => {
                 let x = (self.x / (state.tile_size.as_int() * 0x200)) as usize;
                 let y = (self.y / (state.tile_size.as_int() * 0x200)) as usize;
-                stage.change_tile(x, y, 0);
+                if stage.change_tile(x, y, 0) {
+                    let mut npc = NPC::create(4, &state.npc_table);
+                    npc.cond.set_alive(true);
+                    npc.x = (x as i32) * state.tile_size.as_int() * 0x200;
+                    npc.y = (y as i32) * state.tile_size.as_int() * 0x200;
+                    let _ = npc_list.spawn(0, npc.clone());
+                    let _ = npc_list.spawn(0, npc.clone());
+                    let _ = npc_list.spawn(0, npc);
+                }
 
                 self.action_num = if self.direction == Direction::Left { 10 } else { 30 };
             }

--- a/src/game/npc/boss/heavy_press.rs
+++ b/src/game/npc/boss/heavy_press.rs
@@ -162,12 +162,12 @@ impl BossNPC {
                     // This relies heavily on the map not being changed
                     // Need to calculate offset from the default starting location
                     for i in 0..5 {
-                        stage.change_tile(i + 8, self.parts[0].action_counter3 as usize, 0);
+                        let extra_smoke = if stage.change_tile(i + 8, self.parts[0].action_counter3 as usize, 0) { 3 } else { 0 };
                         npc_list.create_death_smoke(
                             (i as i32 + 8) * 0x2000,
                             self.parts[0].action_counter3 as i32 * 0x2000,
                             0,
-                            4,
+                            4 + extra_smoke,
                             state,
                             &self.parts[0].rng,
                         );

--- a/src/game/npc/mod.rs
+++ b/src/game/npc/mod.rs
@@ -581,7 +581,7 @@ impl GameEntity<([&mut Player; 2], &NPCList, &mut Stage, &mut BulletManager, &mu
             327 => self.tick_n327_sneeze(state, npc_list),
             328 => self.tick_n328_human_transform_machine(state),
             329 => self.tick_n329_laboratory_fan(state),
-            330 => self.tick_n330_rolling(state, stage),
+            330 => self.tick_n330_rolling(state, npc_list, stage),
             331 => self.tick_n331_ballos_bone_projectile(state),
             332 => self.tick_n332_ballos_shockwave(state, npc_list),
             333 => self.tick_n333_ballos_lightning(state, players, npc_list),

--- a/src/game/scripting/tsc/text_script.rs
+++ b/src/game/scripting/tsc/text_script.rs
@@ -1075,8 +1075,9 @@ impl TextScriptVM {
                     npc.x = pos_x as i32 * 0x2000;
                     npc.y = pos_y as i32 * 0x2000;
 
-                    let _ = game_scene.npc_list.spawn(0x100, npc.clone());
-                    let _ = game_scene.npc_list.spawn(0x100, npc);
+                    let _ = game_scene.npc_list.spawn(0, npc.clone());
+                    let _ = game_scene.npc_list.spawn(0, npc.clone());
+                    let _ = game_scene.npc_list.spawn(0, npc);
                 }
 
                 exec_state = TextScriptExecutionState::Running(event, cursor.position() as u32);


### PR DESCRIPTION
Is there some technical reason why the `change_tile` function doesn't just spawn the smoke itself? This seems a bit messy to do it this way...