### PR TITLE
Fix Player gun desync bug and inventory inconsistencies

### DIFF
--- a/src/components/inventory.rs
+++ b/src/components/inventory.rs
@@ -140,24 +140,30 @@ impl GameEntity<(&mut Context, &mut Player, &mut Inventory, &mut HUD)> for Inven
             InventoryFocus::None => {
                 self.focus = InventoryFocus::Weapons;
                 state.control_flags.set_ok_button_disabled(false);
-                state.textscript_vm.start_script(self.get_weapon_event_number(inventory));
+                // check weapon count (0 count means we run item script)
+                state.textscript_vm.start_script( if self.weapon_count > 0 {self.get_weapon_event_number(inventory)} else {self.get_item_event_number(inventory)});
             }
             InventoryFocus::Weapons if state.control_flags.control_enabled() => {
-                if player.controller.trigger_left() {
-                    state.sound_manager.play_sfx(4);
-                    inventory.prev_weapon();
-                    state.control_flags.set_ok_button_disabled(false);
-                    state.textscript_vm.start_script(self.get_weapon_event_number(inventory));
+
+                // if we have no weapons, the TSC should not be refreshed with L/R keystrokes
+                if self.weapon_count > 0
+                {
+                    if player.controller.trigger_left() {
+                        state.sound_manager.play_sfx(4);
+                        inventory.prev_weapon();
+                        state.control_flags.set_ok_button_disabled(false);
+                        state.textscript_vm.start_script(self.get_weapon_event_number(inventory));
+                    }
+    
+                    if player.controller.trigger_right() {
+                        state.sound_manager.play_sfx(4);
+                        inventory.next_weapon();
+                        state.control_flags.set_ok_button_disabled(false);
+                        state.textscript_vm.start_script(self.get_weapon_event_number(inventory));
+                    }
                 }
 
-                if player.controller.trigger_right() {
-                    state.sound_manager.play_sfx(4);
-                    inventory.next_weapon();
-                    state.control_flags.set_ok_button_disabled(false);
-                    state.textscript_vm.start_script(self.get_weapon_event_number(inventory));
-                }
-
-                if player.controller.trigger_up() || player.controller.trigger_down() {
+                if (player.controller.trigger_up() || player.controller.trigger_down()) && self.item_count > 0 {
                     self.focus = InventoryFocus::Items;
                     state.control_flags.set_ok_button_disabled(false);
                     state.textscript_vm.start_script(self.get_item_event_number(inventory));
@@ -310,8 +316,8 @@ impl GameEntity<(&mut Context, &mut Player, &mut Inventory, &mut HUD)> for Inven
 
         let (item_cursor_frame, weapon_cursor_frame) = match self.focus {
             InventoryFocus::None => (1, 1),
-            InventoryFocus::Weapons => (1, self.tick & 1),
-            InventoryFocus::Items => (self.tick & 1, 1),
+            InventoryFocus::Weapons => (1, (self.tick / 2) % 2), //every-other frame (& 1): this is not what we want, we want every 2 frames.
+            InventoryFocus::Items => ((self.tick / 2) % 2, 1),
         };
 
         batch.add_rect(

--- a/src/components/inventory.rs
+++ b/src/components/inventory.rs
@@ -163,6 +163,7 @@ impl GameEntity<(&mut Context, &mut Player, &mut Inventory, &mut HUD)> for Inven
                     }
                 }
 
+                // we should not move from the weapon row if there are no items
                 if (player.controller.trigger_up() || player.controller.trigger_down()) && self.item_count > 0 {
                     self.focus = InventoryFocus::Items;
                     state.control_flags.set_ok_button_disabled(false);

--- a/src/game/player/mod.rs
+++ b/src/game/player/mod.rs
@@ -744,15 +744,15 @@ impl Player {
 
         if self.flags.hit_bottom_wall() {
             if self.cond.interacted() {
-                self.skin.set_state(PlayerAnimationState::Examining);
                 self.anim_num = 11;
                 self.anim_counter = 0;
+                self.skin.set_state(PlayerAnimationState::Examining, self.anim_counter);
             } else if state.control_flags.control_enabled()
                 && (self.controller.move_up() || self.strafe_up)
                 && (self.controller.move_left() || self.controller.move_right())
             {
                 self.cond.set_fallen(true);
-                self.skin.set_state(PlayerAnimationState::WalkingUp);
+                self.skin.set_state(PlayerAnimationState::WalkingUp, self.anim_counter);
 
                 self.anim_counter += 1;
                 if self.anim_counter > 4 {
@@ -771,7 +771,7 @@ impl Player {
                 && (self.controller.move_left() || self.controller.move_right())
             {
                 self.cond.set_fallen(true);
-                self.skin.set_state(PlayerAnimationState::Walking);
+                self.skin.set_state(PlayerAnimationState::Walking, self.anim_counter);
 
                 self.anim_counter += 1;
                 if self.anim_counter > 4 {
@@ -792,7 +792,7 @@ impl Player {
                 }
 
                 self.cond.set_fallen(false);
-                self.skin.set_state(PlayerAnimationState::LookingUp);
+                self.skin.set_state(PlayerAnimationState::LookingUp, self.anim_counter);
                 self.anim_num = 5;
                 self.anim_counter = 0;
             } else {
@@ -801,24 +801,24 @@ impl Player {
                 }
 
                 self.cond.set_fallen(false);
-                self.skin.set_state(PlayerAnimationState::Idle);
+                self.skin.set_state(PlayerAnimationState::Idle, self.anim_counter);
                 self.anim_num = 0;
                 self.anim_counter = 0;
             }
         } else if self.up {
-            self.skin.set_state(PlayerAnimationState::FallingLookingUp);
+            self.skin.set_state(PlayerAnimationState::FallingLookingUp, self.anim_counter);
             self.anim_num = 6;
             self.anim_counter = 0;
         } else if self.down {
-            self.skin.set_state(PlayerAnimationState::FallingLookingDown);
+            self.skin.set_state(PlayerAnimationState::FallingLookingDown, self.anim_counter);
             self.anim_num = 10;
             self.anim_counter = 0;
         } else {
             if self.vel_y > 0 {
-                self.skin.set_state(PlayerAnimationState::Falling);
+                self.skin.set_state(PlayerAnimationState::Falling, self.anim_counter);
                 self.anim_num = 1;
             } else {
-                self.skin.set_state(PlayerAnimationState::Jumping);
+                self.skin.set_state(PlayerAnimationState::Jumping, self.anim_counter);
                 self.anim_num = 3;
             }
             self.anim_counter = 0;
@@ -859,7 +859,7 @@ impl Player {
 
         if state.constants.is_switch && self.air == 0 && self.flags.in_water() && !state.get_flag(4000) {
             self.skin.set_appearance(PlayerAppearanceState::Default);
-            self.skin.set_state(PlayerAnimationState::Drowned);
+            self.skin.set_state(PlayerAnimationState::Drowned, self.anim_counter);
         }
 
         self.anim_rect = self.skin.animation_frame();

--- a/src/game/player/skin/basic.rs
+++ b/src/game/player/skin/basic.rs
@@ -179,10 +179,15 @@ impl PlayerSkin for BasicPlayerSkin {
         }
     }
 
-    fn set_state(&mut self, state: PlayerAnimationState) {
+    fn set_state(&mut self, state: PlayerAnimationState, curr_tick: u16) {
         if self.state != state {
             self.state = state;
-            self.tick = 0;
+
+            //self.tick = 0; // this should not happen
+            //self.tick = curr_tick; // this should happen instead, but there's a problem with ticking on 4 that results in an instant 1st frame animation.
+            // this dirty hack should fix that.
+            self.tick = if curr_tick % 5 == 4 {u16::MAX} else {curr_tick};
+
         }
     }
 

--- a/src/game/player/skin/mod.rs
+++ b/src/game/player/skin/mod.rs
@@ -53,7 +53,7 @@ pub trait PlayerSkin: PlayerSkinClone {
     fn tick(&mut self);
 
     /// Sets the current animation state.
-    fn set_state(&mut self, state: PlayerAnimationState);
+    fn set_state(&mut self, state: PlayerAnimationState, curr_tick: u16);
 
     /// Returns current animation state.
     fn get_state(&self) -> PlayerAnimationState;


### PR DESCRIPTION
  * Found and fixed a bug where the players weapon will not bounce with them in certain cases of common movement, such as spamming up/forward while walking (due to the separation of animation code and behavior code).

  * Changed inventory flashing rate from a duty cycle of 2 ticks to 4. With the original code, it was immediately apparent on my 60Hz monitor that something was off, since the selection cursors appeared to not flash at all.

  * Improved accuracy of empty inventory cursor behavior. With no weapons or items, the player should not be able to move the cursor at all. Currently, the player can move the cursor from "weapons" to "inventory" *(but not back)* when nothing is present in the menu.
  I also found that the weapon TSC could be refreshed on every keypress when in this "empty" state, but this is not the case in CSFreeware or CS+. 
  After experimenting some more with the official engines, I found that once there *was* a weapon in the inventory, *all* keypresses resulted in a TSC update *(including up/down)*. With the rust fix, only left/right will refresh TSC. up/down will still do nothing until an item is present in the inventory. I figured adding the freeware behavior to the inventory would result in too much bloat for a feature that was probably not intended in the first place *(of course, you may feel this way about all of my changes to cursor code)*.


