### PR TITLE
Fix Pixel Birthday easter egg

### DIFF
--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -174,7 +174,7 @@ impl TitleScene {
             song_id = 24;
         }
 
-        if state.settings.soundtrack == "New" && Season::current() == Season::PixelBirthday {
+        if state.settings.soundtrack == "new" && Season::current() == Season::PixelBirthday {
             song_id = 43;
         }
 


### PR DESCRIPTION
The easter egg that plays the Ikachan title screen music on Pixel's birthday doesn't trigger, even when the correct conditions are met. This is due to the string in the settings being in lower-case, while the check is in title-case. Simple one line fix :3