### PR TITLE
Detect controllers from SDL_GameControllerDB correctly

### DIFF
--- a/src/framework/backend_sdl2.rs
+++ b/src/framework/backend_sdl2.rs
@@ -332,7 +332,7 @@ impl BackendEventLoop for SDL2EventLoop {
                             ctx.keyboard_context.set_key(drs_scan, false);
                         }
                     }
-                    Event::ControllerDeviceAdded { which, .. } => {
+                    Event::JoyDeviceAdded { which, .. } => {
                         let game_controller = &self.refs.borrow().game_controller;
 
                         if game_controller.is_game_controller(which) {


### PR DESCRIPTION
SDL generates ControllerDeviceAdded events for controllers that are
already plugged in at the start of the game, but only if those are
recognized as game controllers at the time that we run SDL_Init.
Unfortunately, rust-sdl2 requires initializing SDL before we can call
load_mappings_from_read.

doukutsu-rs ships with this nice gamecontrollerdb.txt file built-into
the binary and loads it at startup, but previously it would not work for
controllers already plugged in before the game started because of the
above. This change works around the ordering issues between recognizing
devices as game controllers and event generation. Instead of using the
ControllerDeviceAdded events, we now use JoyDeviceAdded events. We still
check that the device is a supported game controller, and if it's not
supported then we skip it. The only difference is that controllers in
the gamecontrollerdb.txt database will be detected right away without
unplugging them and plugging them back in while the game is running.
