### PR TITLE
Fix vanilla executable extraction bug

### DIFF
--- a/src/data/vanilla.rs
+++ b/src/data/vanilla.rs
@@ -65,7 +65,7 @@ impl VanillaExtractor {
 
         log::info!("Found vanilla game executable, attempting to extract resources.");
 
-        if filesystem::exists(ctx, format!("{}/stage.sect", data_base_dir.clone())) {
+        if filesystem::exists(ctx, "/stage.sect") {
             log::info!("Vanilla resources are already extracted, not proceeding.");
             return None;
         }


### PR DESCRIPTION
The only physicalFS loaded at this point uses `./data/` already as its root, so it checked for `./data/data/stage.sect`, which is wrong.
As a result, the game would re-extract the vanilla executable files every launch as long as the default exe was in the same directory.