### PR TITLE
Set JP locale on CS+ to ShiftJIS to resolve bug with JP locale (#285)

### DIFF
--- a/src/game/shared_game_state.rs
+++ b/src/game/shared_game_state.rs
@@ -576,6 +576,8 @@ impl SharedGameState {
         } else {
             if (locale.code == "jp" || locale.code == "en") && constants.is_base() {
                 constants.textscript.encoding = TextScriptEncoding::ShiftJIS
+            } else if (locale.code == "jp" && constants.is_cs_plus) {
+                constants.textscript.encoding = TextScriptEncoding::ShiftJIS
             } else {
                 constants.textscript.encoding = TextScriptEncoding::UTF8
             }


### PR DESCRIPTION
@alula last commit which works as intended is [19e0da519f2bac670d53df860bfbf7d52114028a](https://github.com/doukutsu-rs/doukutsu-rs/commit/19e0da519f2bac670d53df860bfbf7d52114028a) the first to break JP locale is commit [47a43467d0fd4e2662a882190f425dcc8d8c45cc](https://github.com/doukutsu-rs/doukutsu-rs/commit/47a43467d0fd4e2662a882190f425dcc8d8c45cc).

ISSUE: Transition from negation of is_switch to is_base()

WHY: JP locale on CS+ needs to be set to ShiftJIS. Commit [47a43467d0fd4e2662a882190f425dcc8d8c45cc](https://github.com/doukutsu-rs/doukutsu-rs/commit/47a43467d0fd4e2662a882190f425dcc8d8c45cc).  sets all other cases to UTF8

FIX:

JP locale on CS+ needs to be set to ShiftJIS. 

Also, the way this if, else is handled should be changed. There has to be a more elegant way to do this.

Tested on Arch with Epic store version with jp bitmap deleted. Please condu

Hopefully this doesn't break anything <3
