### PR TITLE
Fix "More Rust" mode for freeware

### DIFF
--- a/src/components/credits.rs
+++ b/src/components/credits.rs
@@ -79,7 +79,7 @@ impl GameEntity<()> for Credits {
             // draw sue's headband separately because rust doesn't let me mutate the texture set multiple times at once
 
             let headband_spritesheet = {
-                let base = if state.settings.original_textures { "ogph" } else { "plus" };
+                let base = if state.settings.original_textures || state.constants.is_base() { "ogph" } else { "plus" };
                 format!("headband/{}/Casts", base)
             };
 

--- a/src/game/npc/mod.rs
+++ b/src/game/npc/mod.rs
@@ -224,7 +224,7 @@ impl NPC {
     }
 
     fn get_headband_spritesheet(&self, state: &SharedGameState, texture_name: &str) -> String {
-        let base_dir = if state.settings.original_textures { "ogph" } else { "plus" };
+        let base_dir = if state.settings.original_textures || state.constants.is_base() { "ogph" } else { "plus" };
         format!("headband/{}/{}", base_dir, texture_name)
     }
 }


### PR DESCRIPTION
The engine would previously use the upscaled spritesheet for the headbands since the "original_textures" setting is only used with the Nicalis releases.