### PR TITLE
Modifications for Linux handheld devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ category = "Game"
 osx_minimum_system_version = "10.12"
 
 [features]
-default = ["default-base", "backend-sdl", "render-opengl", "exe", "webbrowser", "discord-rpc"]
+default = ["default-base", "backend-sdl", "render-opengl", "exe", "webbrowser", "discord-rpc", "handheld"]
 default-base = ["ogg-playback"]
 ogg-playback = ["lewton"]
 backend-sdl = ["sdl2", "sdl2-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ netplay = ["serde_cbor"]
 editor = []
 exe = []
 android = []
-handheld = []
 
 [dependencies]
 #glutin = { path = "./3rdparty/glutin/glutin", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ netplay = ["serde_cbor"]
 editor = []
 exe = []
 android = []
+handheld = []
 
 [dependencies]
 #glutin = { path = "./3rdparty/glutin/glutin", optional = true }

--- a/src/doukutsu.handheld.patch
+++ b/src/doukutsu.handheld.patch
@@ -1,0 +1,66 @@
+diff --git a/src/framework/backend_sdl2.rs b/src/framework/backend_sdl2.rs
+index 6851f0a..dee116a 100644
+--- a/src/framework/backend_sdl2.rs
++++ b/src/framework/backend_sdl2.rs
+@@ -179,7 +179,17 @@ impl SDL2EventLoop {
+         #[cfg(feature = "render-opengl")]
+         win_builder.opengl();
+ 
+-        let mut window = win_builder.build().map_err(|e| GameError::WindowError(e.to_string()))?;
++        let mut window;
++        match win_builder.build() {
++            Ok(win) => {
++                window = win;
++            }
++            Err(err) => {
++                log::info!("Failed to create Compatibility context, trying GLES");
++                gl_attr.set_context_profile(GLProfile::GLES);
++                window = win_builder.build().map_err(|e| GameError::WindowError(e.to_string()))?;
++            }
++        }
+         #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "horizon")))]
+         {
+             let mut file = filesystem::open(&ctx, "/builtin/icon.bmp").unwrap();
+diff --git a/src/game/settings.rs b/src/game/settings.rs
+index e598415..e2ffe6e 100644
+--- a/src/game/settings.rs
++++ b/src/game/settings.rs
+@@ -140,7 +140,7 @@ fn default_screen_shake_intensity() -> ScreenShakeIntensity {
+ 
+ #[inline(always)]
+ fn default_p1_controller_type() -> ControllerType {
+-    if cfg!(any(target_os = "horizon")) {
++    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
+         ControllerType::Gamepad(0)
+     } else {
+         ControllerType::Keyboard
+@@ -149,7 +149,7 @@ fn default_p1_controller_type() -> ControllerType {
+ 
+ #[inline(always)]
+ fn default_p2_controller_type() -> ControllerType {
+-    if cfg!(any(target_os = "horizon")) {
++    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
+         ControllerType::Gamepad(1)
+     } else {
+         ControllerType::Keyboard
+diff --git a/src/menu/settings_menu.rs b/src/menu/settings_menu.rs
+index ad4fbaf..49356fb 100644
+--- a/src/menu/settings_menu.rs
++++ b/src/menu/settings_menu.rs
+@@ -375,6 +375,7 @@ impl SettingsMenu {
+             MenuEntry::Active(state.loc.t("menus.options_menu.behavior").to_owned()),
+         );
+ 
++        #[cfg(not(any(feature = "handheld")))]
+         self.main
+             .push_entry(MainMenuEntry::Links, MenuEntry::Active(state.loc.t("menus.options_menu.links").to_owned()));
+ 
+@@ -392,7 +393,7 @@ impl SettingsMenu {
+         );
+         self.links.push_entry(LinksMenuEntry::Link(GETPLUS_LINK), MenuEntry::Active("Get Cave Story+".to_owned()));
+ 
+-        #[cfg(not(any(target_os = "horizon")))]
++        #[cfg(not(any(target_os = "horizon", feature = "handheld")))]
+         self.main.push_entry(
+             MainMenuEntry::Advanced,
+             MenuEntry::Active(state.loc.t("menus.options_menu.advanced").to_owned()),

--- a/src/framework/backend_sdl2.rs
+++ b/src/framework/backend_sdl2.rs
@@ -179,7 +179,17 @@ impl SDL2EventLoop {
         #[cfg(feature = "render-opengl")]
         win_builder.opengl();
 
-        let mut window = win_builder.build().map_err(|e| GameError::WindowError(e.to_string()))?;
+        let mut window;
+        match win_builder.build() {
+            Ok(win) => {
+                window = win;
+            }
+            Err(err) => {
+                log::info!("Failed to create Compatibility context, trying GLES");
+                gl_attr.set_context_profile(GLProfile::GLES);
+                window = win_builder.build().map_err(|e| GameError::WindowError(e.to_string()))?;
+            }
+        }
         #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "horizon")))]
         {
             let mut file = filesystem::open(&ctx, "/builtin/icon.bmp").unwrap();

--- a/src/framework/render_opengl.rs
+++ b/src/framework/render_opengl.rs
@@ -673,8 +673,6 @@ impl BackendRenderer for OpenGLRenderer {
                     self.render_data.surf_texture,
                     BackendShader::Texture,
                 )?;
-
-                gl.gl.Finish();
             }
 
             if let Some((context, _)) = self.get_context() {

--- a/src/game/settings.rs
+++ b/src/game/settings.rs
@@ -140,7 +140,7 @@ fn default_screen_shake_intensity() -> ScreenShakeIntensity {
 
 #[inline(always)]
 fn default_p1_controller_type() -> ControllerType {
-    cfg!(any(target_os = "horizon", feature = "handheld")) {
+    if cfg!(any(target_os = "horizon", feature = "handheld")) {
         ControllerType::Gamepad(0)
     } else {
         ControllerType::Keyboard
@@ -149,7 +149,7 @@ fn default_p1_controller_type() -> ControllerType {
 
 #[inline(always)]
 fn default_p2_controller_type() -> ControllerType {
-    cfg!(any(target_os = "horizon", feature = "handheld")) {
+    if cfg!(any(target_os = "horizon", feature = "handheld")) {
         ControllerType::Gamepad(1)
     } else {
         ControllerType::Keyboard

--- a/src/game/settings.rs
+++ b/src/game/settings.rs
@@ -140,7 +140,7 @@ fn default_screen_shake_intensity() -> ScreenShakeIntensity {
 
 #[inline(always)]
 fn default_p1_controller_type() -> ControllerType {
-    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
+    cfg!(any(target_os = "horizon", feature = "handheld")) {
         ControllerType::Gamepad(0)
     } else {
         ControllerType::Keyboard
@@ -149,7 +149,7 @@ fn default_p1_controller_type() -> ControllerType {
 
 #[inline(always)]
 fn default_p2_controller_type() -> ControllerType {
-    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
+    cfg!(any(target_os = "horizon", feature = "handheld")) {
         ControllerType::Gamepad(1)
     } else {
         ControllerType::Keyboard

--- a/src/game/settings.rs
+++ b/src/game/settings.rs
@@ -140,7 +140,7 @@ fn default_screen_shake_intensity() -> ScreenShakeIntensity {
 
 #[inline(always)]
 fn default_p1_controller_type() -> ControllerType {
-    if cfg!(any(target_os = "horizon")) {
+    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
         ControllerType::Gamepad(0)
     } else {
         ControllerType::Keyboard
@@ -149,7 +149,7 @@ fn default_p1_controller_type() -> ControllerType {
 
 #[inline(always)]
 fn default_p2_controller_type() -> ControllerType {
-    if cfg!(any(target_os = "horizon")) {
+    if cfg!(any(target_os = "horizon")) || cfg!(any(feature = "handheld")) {
         ControllerType::Gamepad(1)
     } else {
         ControllerType::Keyboard

--- a/src/menu/settings_menu.rs
+++ b/src/menu/settings_menu.rs
@@ -375,6 +375,7 @@ impl SettingsMenu {
             MenuEntry::Active(state.loc.t("menus.options_menu.behavior").to_owned()),
         );
 
+        #[cfg(not(any(feature = "handheld")))]
         self.main
             .push_entry(MainMenuEntry::Links, MenuEntry::Active(state.loc.t("menus.options_menu.links").to_owned()));
 
@@ -392,7 +393,7 @@ impl SettingsMenu {
         );
         self.links.push_entry(LinksMenuEntry::Link(GETPLUS_LINK), MenuEntry::Active("Get Cave Story+".to_owned()));
 
-        #[cfg(not(any(target_os = "horizon")))]
+        #[cfg(not(any(target_os = "horizon", feature = "handheld")))]
         self.main.push_entry(
             MainMenuEntry::Advanced,
             MenuEntry::Active(state.loc.t("menus.options_menu.advanced").to_owned()),


### PR DESCRIPTION
Hello,

Thank you for your great work on this project! I have been enjoying playing Cave Story + on my linux handheld device (Anbernic RG40xx). I found that some minor changes were needed to get it running, which are included in this PR:

1. These devices only have GLES, and so I modified the code to create a GLES surface if the Compatibility surface fails. (You will be able to tell from this that I am not a Rust programmer :-)
2. They also have no keyboard, so I added a 'handheld' feature which defaults to using controllers for players 1 and 2.
3. They don't have web browsers either, and the advanced options fail, so I disabled the links and advanced menu items when the handheld feature is enabled.

(I also needed to do use pkgconfig for the SDL packages in Cargo.toml, but this is obviously not in the PR:
```
-sdl2 = { git = "https://github.com/doukutsu-rs/rust-sdl2.git", rev = "f2f1e29a416bcc22f2faf411866db2c8d9536308", optional = true, features = ["unsafe_textures", "bundled", "static-link"] }
-sdl2-sys = { git = "https://github.com/doukutsu-rs/rust-sdl2.git", rev = "f2f1e29a416bcc22f2faf411866db2c8d9536308", optional = true, features = ["bundled", "static-link"] }
+sdl2 = { git = "https://github.com/doukutsu-rs/rust-sdl2.git", rev = "f2f1e29a416bcc22f2faf411866db2c8d9536308", optional = true, features = ["unsafe_textures", "use-pkgconfig"] }
+sdl2-sys = { git = "https://github.com/doukutsu-rs/rust-sdl2.git", rev = "f2f1e29a416bcc22f2faf411866db2c8d9536308", optional = true, features = ["use-pkgconfig"] }
```)