### PR TITLE
Remove glFinish

### DIFF
--- a/src/framework/render_opengl.rs
+++ b/src/framework/render_opengl.rs
@@ -673,8 +673,6 @@ impl BackendRenderer for OpenGLRenderer {
                     self.render_data.surf_texture,
                     BackendShader::Texture,
                 )?;
-
-                gl.gl.Finish();
             }
 
             if let Some((context, _)) = self.get_context() {


### PR DESCRIPTION
glFinish waits until rendering is complete.
This should only be required on single buffered output which I don't think we have.

Removing it improves performance on (very) low end hardware.