### PR TITLE
Fix washed-out colors in refactor branch

### DIFF
--- a/src/components/background.rs
+++ b/src/components/background.rs
@@ -42,7 +42,7 @@ impl Background {
 
         match stage.data.background_type {
             BackgroundType::TiledStatic => {
-                graphics::clear(ctx, stage.data.background_color);
+                graphics::clear(ctx, stage.data.background_color.into());
 
                 let (bg_width, bg_height) = (batch.width() as i32, batch.height() as i32);
                 let count_x = state.canvas_size.0 as i32 / bg_width + 1;
@@ -55,7 +55,7 @@ impl Background {
                 }
             }
             BackgroundType::TiledParallax | BackgroundType::Tiled | BackgroundType::Waterway => {
-                graphics::clear(ctx, stage.data.background_color);
+                graphics::clear(ctx, stage.data.background_color.into());
 
                 let (off_x, off_y) = if stage.data.background_type == BackgroundType::Tiled {
                     (frame_x % (batch.width() as f32), frame_y % (batch.height() as f32))
@@ -77,13 +77,13 @@ impl Background {
                 }
             }
             BackgroundType::Water => {
-                graphics::clear(ctx, stage.data.background_color);
+                graphics::clear(ctx, stage.data.background_color.into());
             }
             BackgroundType::Black => {
-                graphics::clear(ctx, stage.data.background_color);
+                graphics::clear(ctx, stage.data.background_color.into());
             }
             BackgroundType::Scrolling => {
-                graphics::clear(ctx, stage.data.background_color);
+                graphics::clear(ctx, stage.data.background_color.into());
 
                 let (bg_width, bg_height) = (batch.width() as i32, batch.height() as i32);
                 let offset_x = self.tick as f32 % (bg_width as f32 / 3.0);
@@ -102,7 +102,7 @@ impl Background {
                 }
             }
             BackgroundType::OutsideWind | BackgroundType::Outside | BackgroundType::OutsideUnknown => {
-                graphics::clear(ctx, Color::from_rgb(0, 0, 0));
+                graphics::clear(ctx, Color::from_rgb(0, 0, 0).into());
 
                 let offset_x = (self.tick % 640) as i32;
                 let offset_y = ((state.canvas_size.1 - 240.0) / 2.0).floor();

--- a/src/components/credits.rs
+++ b/src/components/credits.rs
@@ -42,7 +42,7 @@ impl GameEntity<()> for Credits {
 
     fn draw(&self, state: &mut SharedGameState, ctx: &mut Context, _frame: &Frame) -> GameResult {
         let rect = Rect::new(0, 0, (state.screen_size.0 / 2.0) as _, state.screen_size.1 as _);
-        graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 32))?;
+        graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 32).into())?;
 
         if state.textscript_vm.illustration_state != IllustrationState::Hidden {
             let x = match state.textscript_vm.illustration_state {

--- a/src/components/falling_island.rs
+++ b/src/components/falling_island.rs
@@ -38,7 +38,7 @@ impl GameEntity<()> for FallingIsland {
             (80.0 * state.scale) as _,
         );
 
-        graphics::clear(ctx, Color::from_rgb(0, 0, 32));
+        graphics::clear(ctx, Color::from_rgb(0, 0, 32).into());
         graphics::set_clip_rect(ctx, Some(clip_rect))?;
 
         static RECT_BG: Rect<u16> = Rect { left: 0, top: 0, right: 160, bottom: 80 };

--- a/src/components/flash.rs
+++ b/src/components/flash.rs
@@ -1,4 +1,4 @@
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::entity::GameEntity;
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;
@@ -59,7 +59,7 @@ impl GameEntity<()> for Flash {
     }
 
     fn draw(&self, state: &mut SharedGameState, ctx: &mut Context, frame: &Frame) -> GameResult<()> {
-        const WHITE: Color = Color::new(1.0, 1.0, 1.0, 1.0);
+        const WHITE: Colorf = Colorf::from_rgba(1.0, 1.0, 1.0, 1.0);
 
         match self.state {
             FlashState::None => {}

--- a/src/components/map_system.rs
+++ b/src/components/map_system.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::backend::{BackendTexture, SpriteBatchCommand};
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;
@@ -49,7 +49,7 @@ impl MapSystem {
         *self.has_map_data.borrow_mut() = true;
 
         graphics::set_render_target(ctx, self.texture.borrow().as_ref())?;
-        graphics::clear(ctx, Color::new(0.0, 0.0, 0.0, 1.0));
+        graphics::clear(ctx, Colorf::from_rgba(0.0, 0.0, 0.0, 1.0));
 
         let batch = state.texture_set.get_or_load_batch(ctx, &state.constants, "TextBox")?;
 
@@ -195,7 +195,7 @@ impl MapSystem {
         );
 
         if !state.constants.is_switch {
-            graphics::draw_rect(ctx, rect_black_bar, Color::new(0.0, 0.0, 0.0, 1.0))?;
+            graphics::draw_rect(ctx, rect_black_bar, Colorf::from_rgba(0.0, 0.0, 0.0, 1.0))?;
         }
 
         let map_name = if state.constants.is_cs_plus && state.settings.locale == "jp" {
@@ -225,7 +225,7 @@ impl MapSystem {
                     height * 2,
                 );
 
-                graphics::draw_rect(ctx, rect, Color::new(0.0, 0.0, 0.0, 1.0))?;
+                graphics::draw_rect(ctx, rect, Colorf::from_rgba(0.0, 0.0, 0.0, 1.0))?;
 
                 return Ok(());
             }
@@ -245,7 +245,7 @@ impl MapSystem {
             height_border as isize,
         );
 
-        graphics::draw_rect(ctx, rect, Color::new(0.0, 0.0, 0.0, 1.0))?;
+        graphics::draw_rect(ctx, rect, Colorf::from_rgba(0.0, 0.0, 0.0, 1.0))?;
 
         if let Some(tex) = self.texture.borrow_mut().as_mut() {
             let width = state.scale * stage.map.width as f32;

--- a/src/components/text_boxes.rs
+++ b/src/components/text_boxes.rs
@@ -268,7 +268,7 @@ impl GameEntity<()> for TextBoxes {
                         (5.0 * state.scale) as isize,
                         (state.font.line_height() * state.scale) as isize,
                     ),
-                    Color::from_rgb(255, 255, 255),
+                    Color::from_rgb(255, 255, 255).into(),
                 )?;
             }
         }

--- a/src/components/water_renderer.rs
+++ b/src/components/water_renderer.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::backend::{BackendShader, SpriteBatchCommand, VertexData};
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;
@@ -240,7 +240,7 @@ impl WaterRenderer {
         layer: WaterLayer,
     ) -> GameResult<()> {
         graphics::set_render_target(ctx, state.lightmap_canvas.as_ref())?;
-        graphics::clear(ctx, Color::from_rgba(0, 0, 0, 0));
+        graphics::clear(ctx, Colorf::from_rgba(0., 0., 0., 0.));
         graphics::set_blend_mode(ctx, BlendMode::None)?;
 
         let (o_x, o_y) = frame.xy_interpolated(state.frame_time);

--- a/src/engine_constants/mod.rs
+++ b/src/engine_constants/mod.rs
@@ -6,7 +6,7 @@ use case_insensitive_hashmap::CaseInsensitiveHashMap;
 use xmltree::Element;
 
 use crate::case_insensitive_hashmap;
-use crate::common::{BulletFlag, Color, Rect};
+use crate::common::{BulletFlag, Color, Colorf, Rect};
 use crate::engine_constants::npcs::NPCConsts;
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;

--- a/src/framework/backend.rs
+++ b/src/framework/backend.rs
@@ -9,6 +9,7 @@ use super::error::GameResult;
 use super::graphics::BlendMode;
 use super::graphics::SwapMode;
 
+use crate::common::Colorf;
 use crate::common::{Color, Rect};
 use crate::game::Game;
 
@@ -47,7 +48,7 @@ pub trait BackendRenderer {
     fn renderer_name(&self) -> String;
 
     /// Clear the current render target with the specified color.
-    fn clear(&mut self, color: Color);
+    fn clear(&mut self, color: Colorf);
 
     /// Present the current frame to the screen.
     fn present(&mut self) -> GameResult;
@@ -75,7 +76,7 @@ pub trait BackendRenderer {
     fn set_render_target(&mut self, texture: Option<&Box<dyn BackendTexture>>) -> GameResult;
 
     /// Draw a filled rectangle with the specified color.
-    fn draw_rect(&mut self, rect: Rect, color: Color) -> GameResult;
+    fn draw_rect(&mut self, rect: Rect, color: Colorf) -> GameResult;
 
     /// Draw an outlined rectangle with the specified line width and color.
     fn draw_outline_rect(&mut self, rect: Rect, line_width: usize, color: Color) -> GameResult;

--- a/src/framework/backend_null.rs
+++ b/src/framework/backend_null.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use imgui::{DrawData, TextureId, Ui};
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::backend::{
     Backend, BackendEventLoop, BackendRenderer, BackendShader, BackendTexture, SpriteBatchCommand, VertexData,
 };
@@ -96,7 +96,7 @@ impl BackendRenderer for NullRenderer {
         "Null".to_owned()
     }
 
-    fn clear(&mut self, _color: Color) {}
+    fn clear(&mut self, _color: Colorf) {}
 
     fn present(&mut self) -> GameResult {
         Ok(())
@@ -118,7 +118,7 @@ impl BackendRenderer for NullRenderer {
         Ok(())
     }
 
-    fn draw_rect(&mut self, _rect: Rect<isize>, _color: Color) -> GameResult {
+    fn draw_rect(&mut self, _rect: Rect<isize>, _color: Colorf) -> GameResult {
         Ok(())
     }
 

--- a/src/framework/backend_sdl2.rs
+++ b/src/framework/backend_sdl2.rs
@@ -26,7 +26,7 @@ use sdl2::video::Window;
 use sdl2::video::WindowContext;
 use sdl2::{controller, keyboard, pixels, EventPump, GameControllerSubsystem, Sdl, VideoSubsystem};
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::backend::{
     Backend, BackendEventLoop, BackendGamepad, BackendRenderer, BackendShader, BackendTexture, SpriteBatchCommand,
     VertexData,
@@ -720,11 +720,11 @@ impl BackendRenderer for SDL2Renderer {
         "*COMPATIBILITY* SDL2_Renderer".to_owned()
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, color: Colorf) {
         let mut refs = self.refs.borrow_mut();
         let canvas = refs.window.canvas();
 
-        canvas.set_draw_color(to_sdl(color));
+        canvas.set_draw_color(to_sdl(color.to_srgb()));
         canvas.set_blend_mode(sdl2::render::BlendMode::Blend);
         canvas.clear();
     }
@@ -827,12 +827,12 @@ impl BackendRenderer for SDL2Renderer {
         Ok(())
     }
 
-    fn draw_rect(&mut self, rect: Rect<isize>, color: Color) -> GameResult<()> {
+    fn draw_rect(&mut self, rect: Rect<isize>, color: Colorf) -> GameResult<()> {
         let mut refs = self.refs.borrow_mut();
         let blend = refs.blend_mode;
         let canvas = refs.window.canvas();
 
-        let (r, g, b, a) = color.to_rgba();
+        let (r, g, b, a) = color.to_srgb().to_rgba();
 
         canvas.set_draw_color(pixels::Color::RGBA(r, g, b, a));
         canvas.set_blend_mode(blend);

--- a/src/framework/graphics.rs
+++ b/src/framework/graphics.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::backend::{BackendShader, BackendTexture, VertexData};
 use crate::framework::context::Context;
 use crate::framework::error::{GameError, GameResult};
@@ -33,7 +33,7 @@ pub enum SwapMode {
     Adaptive = -1,
 }
 
-pub fn clear(ctx: &mut Context, color: Color) {
+pub fn clear(ctx: &mut Context, color: Colorf) {
     if let Some(renderer) = &mut ctx.renderer {
         renderer.clear(color)
     }
@@ -108,7 +108,7 @@ pub fn set_blend_mode(ctx: &mut Context, blend: BlendMode) -> GameResult {
     Err(GameError::RenderError("Rendering backend hasn't been initialized yet.".to_string()))
 }
 
-pub fn draw_rect(ctx: &mut Context, rect: Rect, color: Color) -> GameResult {
+pub fn draw_rect(ctx: &mut Context, rect: Rect, color: Colorf) -> GameResult {
     if let Some(renderer) = &mut ctx.renderer {
         return renderer.draw_rect(rect, color);
     }

--- a/src/framework/render_opengl.rs
+++ b/src/framework/render_opengl.rs
@@ -21,7 +21,7 @@ use super::gl::types::*;
 use super::graphics::BlendMode;
 use super::graphics::SwapMode;
 use super::util::{field_offset, return_param};
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::game::GAME_SUSPENDED;
 
 pub trait GLPlatformFunctions {
@@ -707,7 +707,7 @@ impl BackendRenderer for OpenGLRenderer {
         }
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, color: Colorf) {
         unsafe {
             let gl = &self.gl;
             gl.gl.ClearColor(color.r, color.g, color.b, color.a);
@@ -1002,10 +1002,10 @@ impl BackendRenderer for OpenGLRenderer {
         Ok(())
     }
 
-    fn draw_rect(&mut self, rect: Rect<isize>, color: Color) -> GameResult {
+    fn draw_rect(&mut self, rect: Rect<isize>, color: Colorf) -> GameResult {
         unsafe {
             let gl = &self.gl;
-            let color = color.to_rgba();
+            let color = color.to_srgb().to_rgba();
             let mut uv = self.render_data.font_tex_size;
             uv.0 = 0.0 / uv.0;
             uv.1 = 0.0 / uv.1;

--- a/src/framework/render_wgpu.rs
+++ b/src/framework/render_wgpu.rs
@@ -13,7 +13,7 @@ use wgpu::{
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 
 use super::{
     backend::{BackendRenderer, BackendShader, BackendTexture, SpriteBatchCommand, VertexData},
@@ -30,7 +30,7 @@ const fn convert_swap_mode(swap_mode: SwapMode) -> wgpu::PresentMode {
     }
 }
 
-const fn to_wgpu_color(color: Color) -> wgpu::Color {
+const fn to_wgpu_color(color: Colorf) -> wgpu::Color {
     wgpu::Color { r: color.r as _, g: color.g as _, b: color.b as _, a: color.a as _ }
 }
 
@@ -602,7 +602,7 @@ impl BackendRenderer for WGPURenderer {
         Ok(())
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, color: Colorf) {
         let view = self.ctx.render_target.borrow();
         let view = if let Some(rt) = view.as_ref() {
             rt
@@ -641,7 +641,7 @@ impl BackendRenderer for WGPURenderer {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
-            format: TextureFormat::Rgba8Unorm,
+            format: TextureFormat::Rgba8UnormSrgb,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
             view_formats: &[],
         });
@@ -658,7 +658,7 @@ impl BackendRenderer for WGPURenderer {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: TextureDimension::D2,
-                format: TextureFormat::Rgba8Unorm,
+                format: TextureFormat::Rgba8UnormSrgb,
                 usage: TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             },
@@ -692,7 +692,7 @@ impl BackendRenderer for WGPURenderer {
         Ok(())
     }
 
-    fn draw_rect(&mut self, _rect: Rect<isize>, _color: Color) -> GameResult {
+    fn draw_rect(&mut self, _rect: Rect<isize>, _color: Colorf) -> GameResult {
         Ok(())
     }
 

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use byteorder::{ReadBytesExt, LE};
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::framework::context::Context;
 use crate::framework::error::GameError::ResourceLoadError;
 use crate::framework::error::{GameError, GameResult};
@@ -631,9 +631,9 @@ impl WaterParams {
 
     pub fn get_entry(&self, tile: u8) -> &WaterParamEntry {
         static DEFAULT_ENTRY: WaterParamEntry = WaterParamEntry {
-            color_top: Color::new(1.0, 1.0, 1.0, 1.0),
-            color_middle: Color::new(1.0, 1.0, 1.0, 1.0),
-            color_bottom: Color::new(1.0, 1.0, 1.0, 1.0),
+            color_top: Color::from_rgba(255, 255, 255, 255),
+            color_middle: Color::from_rgba(255, 255, 255, 255),
+            color_bottom: Color::from_rgba(255, 255, 255, 255),
         };
 
         self.entries.get(&tile).unwrap_or(&DEFAULT_ENTRY)

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 
 use scripting::tsc::text_script::ScriptMode;
 
+use crate::common::Colorf;
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;
 use crate::framework::graphics::{self, SwapMode};
@@ -208,7 +209,7 @@ impl Game {
         self.loops = 0;
 
         graphics::prepare_draw(ctx)?;
-        graphics::clear(ctx, [0.0, 0.0, 0.0, 1.0].into());
+        graphics::clear(ctx, Colorf::from_rgba(0.0, 0.0, 0.0, 1.0));
 
         if let Some(scene) = self.scene.get_mut() {
             let state_ref = self.state.get_mut();

--- a/src/game/player/skin/basic.rs
+++ b/src/game/player/skin/basic.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 
-use crate::common::{Color, Direction, Rect};
+use crate::common::{Color, Colorf, Direction, Rect};
 use crate::framework::context::Context;
 use crate::framework::filesystem;
 use crate::framework::filesystem::File;
@@ -107,7 +107,7 @@ impl BasicPlayerSkin {
 
         BasicPlayerSkin {
             texture_name,
-            color: Color::new(1.0, 1.0, 1.0, 1.0),
+            color: Color::from_rgba(255, 255, 255, 255),
             state: PlayerAnimationState::Idle,
             appearance: PlayerAppearanceState::Default,
             direction: Direction::Left,

--- a/src/game/player/skin/mod.rs
+++ b/src/game/player/skin/mod.rs
@@ -1,6 +1,6 @@
 use bitfield::bitfield;
 
-use crate::common::{Color, Direction, Rect};
+use crate::common::{Color, Colorf, Direction, Rect};
 use crate::game::physics::HitExtents;
 use crate::game::shared_game_state::SharedGameState;
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use crate::common::{Color, Rect};
+use crate::common::{Color, Colorf, Rect};
 use crate::components::draw_common::{draw_number, Alignment};
 use crate::framework::context::Context;
 use crate::framework::error::GameResult;
@@ -589,10 +589,10 @@ impl<T: std::cmp::PartialEq + std::default::Default + Clone> Menu<T> {
                                 (75.0 * scale) as isize,
                                 (8.0 * scale) as isize,
                             ),
-                            Color::new(0.0, 0.0, 0.0, 1.0),
+                            Colorf::from_rgba(0.0, 0.0, 0.0, 1.0),
                         )?;
 
-                        graphics::draw_rect(ctx, bar_rect, Color::new(1.0, 1.0, 1.0, 1.0))?;
+                        graphics::draw_rect(ctx, bar_rect, Colorf::from_rgba(1.0, 1.0, 1.0, 1.0))?;
                     }
 
                     if state.settings.touch_controls {

--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use log::info;
 
-use crate::common::{interpolate_fix9_scale, Color, Direction, Rect};
+use crate::common::{interpolate_fix9_scale, Color, Colorf, Direction, Rect};
 use crate::components::background::Background;
 use crate::components::boss_life_bar::BossLifeBar;
 use crate::components::credits::Credits;
@@ -331,7 +331,7 @@ impl GameScene {
 
         if left_side > 0.0 {
             let rect = Rect::new(0, 0, left_side as isize, canvas_h_scaled as isize);
-            graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 0))?;
+            graphics::draw_rect(ctx, rect, Colorf::from_rgb(0., 0., 0.))?;
         }
 
         if right_side < canvas_w_scaled {
@@ -341,17 +341,17 @@ impl GameScene {
                 (state.canvas_size.0 * state.scale) as isize,
                 (state.canvas_size.1 * state.scale) as isize,
             );
-            graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 0))?;
+            graphics::draw_rect(ctx, rect, Colorf::from_rgb(0., 0., 0.))?;
         }
 
         if upper_side > 0.0 {
             let rect = Rect::new(0, 0, canvas_w_scaled as isize, upper_side as isize);
-            graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 0))?;
+            graphics::draw_rect(ctx, rect, Colorf::from_rgb(0., 0., 0.))?;
         }
 
         if lower_side < canvas_h_scaled {
             let rect = Rect::new(0, lower_side as isize, canvas_w_scaled as isize, canvas_h_scaled as isize);
-            graphics::draw_rect(ctx, rect, Color::from_rgb(0, 0, 0))?;
+            graphics::draw_rect(ctx, rect, Colorf::from_rgb(0., 0., 0.))?;
         }
 
         Ok(())
@@ -511,7 +511,7 @@ impl GameScene {
 
         graphics::set_blend_mode(ctx, BlendMode::Add)?;
 
-        graphics::clear(ctx, Color::from_rgb(100, 100, 110));
+        graphics::clear(ctx, Color::from_rgb(100, 100, 110).into());
 
         for npc in self.npc_list.iter_alive() {
             if npc.x < (self.frame.x - 128 * 0x200 - npc.display_bounds.width() as i32 * 0x200)
@@ -1093,7 +1093,7 @@ impl GameScene {
                     right: (state.screen_size.0 + 1.0) as isize,
                     bottom: (state.screen_size.1 + 1.0) as isize,
                 },
-                Color { r: 0.15, g: 0.12, b: 0.12, a: 1.0 },
+                Colorf { r: 0.15, g: 0.12, b: 0.12, a: 1.0 },
             )?;
             graphics::set_render_target(ctx, None)?;
             graphics::set_blend_mode(ctx, BlendMode::Add)?;
@@ -2034,7 +2034,7 @@ impl Scene for GameScene {
 
         if self.inventory_dim > 0.0 {
             let rect = Rect::new(0, 0, state.screen_size.0 as isize + 1, state.screen_size.1 as isize + 1);
-            let mut dim_color = state.constants.inventory_dim_color;
+            let mut dim_color: Colorf = state.constants.inventory_dim_color.into();
             dim_color.a *= self.inventory_dim;
             graphics::draw_rect(ctx, rect, dim_color)?;
         }
@@ -2222,14 +2222,14 @@ impl Scene for GameScene {
                 ((10.0 + line_height) * state.scale) as isize,
             );
 
-            draw_rect(ctx, rect, Color::from_rgb(0, 0, 32))?;
+            draw_rect(ctx, rect, Color::from_rgb(0, 0, 32).into())?;
 
             rect.right = rect.left + (w * state.scale) as isize;
-            draw_rect(ctx, rect, Color::from_rgb(128, 128, 160))?;
+            draw_rect(ctx, rect, Color::from_rgb(128, 128, 160).into())?;
 
             rect.left = ((state.canvas_size.0 - w) * state.scale) as isize;
             rect.right = rect.left + (w * state.scale).ceil() as isize;
-            draw_rect(ctx, rect, Color::from_rgb(128, 128, 160))?;
+            draw_rect(ctx, rect, Color::from_rgb(128, 128, 160).into())?;
 
             state.font.builder().position(pos_x + 10.0, pos_y + 5.0).shadow(true).with_symbols(Some(symbols)).draw(
                 &text,

--- a/src/scene/jukebox_scene.rs
+++ b/src/scene/jukebox_scene.rs
@@ -76,7 +76,7 @@ impl JukeboxScene {
                 pxpack_data: None,
                 background: crate::game::stage::Background::new("bkMoon"),
                 background_type: BackgroundType::Outside,
-                background_color: Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+                background_color: Color { r: 0, g: 0, b: 0, a: 0 },
                 npc1: NpcType::new("0"),
                 npc2: NpcType::new("0"),
             },

--- a/src/scene/no_data_scene.rs
+++ b/src/scene/no_data_scene.rs
@@ -51,7 +51,7 @@ impl Scene for NoDataScene {
     }
 
     fn draw(&self, state: &mut SharedGameState, ctx: &mut Context) -> GameResult {
-        graphics::clear(ctx, Color::from_rgb(30, 0, 0));
+        graphics::clear(ctx, Color::from_rgb(30, 0, 0).into());
 
         state.font.builder().center(state.canvas_size.0).y(10.0).color((255, 100, 100, 255)).draw(
             "doukutsu-rs internal error",

--- a/src/scene/title_scene.rs
+++ b/src/scene/title_scene.rs
@@ -107,7 +107,7 @@ impl TitleScene {
                 pxpack_data: None,
                 background: crate::game::stage::Background::new("bkMoon"),
                 background_type: BackgroundType::Outside,
-                background_color: Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+                background_color: Color { r: 0, g: 0, b: 0, a: 0 },
                 npc1: NpcType::new("0"),
                 npc2: NpcType::new("0"),
             },


### PR DESCRIPTION
This PR addresses washed-out colors in the refactor branch, which are caused by incorrectly applying sRGB correction. To fix this, the Color struct has been refactored into two distinct structs:
- "Color" represents sRGB encoded values (0-255 range).
- "Colorf represents linear color values (0.0-1.0).

This PR is still a draft because more testing is needed, particularly for non-wgpu backends.