### PR TITLE
sound: reuse buffers

### DIFF
--- a/src/sound/mod.rs
+++ b/src/sound/mod.rs
@@ -84,16 +84,16 @@ impl SoundManager {
         }
 
         let bnk = wave_bank::SoundBank::load_from(filesystem::open(ctx, "/builtin/organya-wavetable-doukutsu.bin")?)?;
-        Ok(SoundManager::bootstrap(&bnk, tx, rx)?)
+        Ok(SoundManager::bootstrap(bnk, tx, rx)?)
     }
 
     fn bootstrap(
-        soundbank: &SoundBank,
+        soundbank: SoundBank,
         tx: Sender<PlaybackMessage>,
         rx: Receiver<PlaybackMessage>,
     ) -> GameResult<SoundManager> {
         let mut sound_manager = SoundManager {
-            soundbank: Some(soundbank.to_owned()),
+            soundbank: Some(soundbank.clone()),
             tx,
             prev_song_id: 0,
             current_song_id: 0,
@@ -126,16 +126,16 @@ impl SoundManager {
         let config = config_result.unwrap();
 
         let res = match config.sample_format() {
-            cpal::SampleFormat::I8 => run::<i8>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::I16 => run::<i16>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::I32 => run::<i32>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::I64 => run::<i64>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::U8 => run::<u8>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::U16 => run::<u16>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::U32 => run::<u32>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::U64 => run::<u64>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::F32 => run::<f32>(rx, soundbank.to_owned(), device, config.into()),
-            cpal::SampleFormat::F64 => run::<f64>(rx, soundbank.to_owned(), device, config.into()),
+            cpal::SampleFormat::I8 => run::<i8>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::I16 => run::<i16>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::I32 => run::<i32>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::I64 => run::<i64>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::U8 => run::<u8>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::U16 => run::<u16>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::U32 => run::<u32>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::U64 => run::<u64>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::F32 => run::<f32>(rx, soundbank.clone(), device, config.into()),
+            cpal::SampleFormat::F64 => run::<f64>(rx, soundbank.clone(), device, config.into()),
             _ => Err(AudioError("Unsupported sample format.".to_owned())),
         };
 
@@ -157,7 +157,7 @@ impl SoundManager {
 
         let (tx, rx): (Sender<PlaybackMessage>, Receiver<PlaybackMessage>) = mpsc::channel();
         let soundbank = self.soundbank.take().unwrap();
-        *self = SoundManager::bootstrap(&soundbank, tx, rx)?;
+        *self = SoundManager::bootstrap(soundbank, tx, rx)?;
 
         Ok(())
     }

--- a/src/sound/org_playback.rs
+++ b/src/sound/org_playback.rs
@@ -1,14 +1,15 @@
 use std::cmp::min;
 use std::hint::unreachable_unchecked;
 use std::mem::MaybeUninit;
+use std::sync::Arc;
 
 use crate::sound::fir::FIR;
 use crate::sound::fir::FIR_STEP;
-use crate::sound::InterpolationMode;
 use crate::sound::organya::{Song as Organya, Version};
 use crate::sound::stuff::*;
 use crate::sound::wav::*;
 use crate::sound::wave_bank::SoundBank;
+use crate::sound::InterpolationMode;
 
 #[derive(Clone)]
 pub struct FIRData {
@@ -107,7 +108,7 @@ impl OrgPlaybackEngine {
 
             let format = WavFormat { channels: 1, sample_rate: 22050, bit_depth: 8 };
 
-            let rbuf = RenderBuffer::new_organya(WavSample { format, data: sound });
+            let rbuf = RenderBuffer::new_organya(format, sound);
 
             for j in 0..8 {
                 for &k in &[0, 64] {
@@ -120,10 +121,14 @@ impl OrgPlaybackEngine {
         for (idx, (track, buf)) in song.tracks[8..].iter().zip(self.track_buffers[128..].iter_mut()).enumerate() {
             if song.version == Version::Extended {
                 // Check for OOB track count, instruments outside of the sample range will be set to the last valid sample
-                let index = if track.inst.inst as usize >= samples.samples.len() {samples.samples.len() - 1} else {track.inst.inst as usize} ;
+                let index = if track.inst.inst as usize >= samples.samples.len() {
+                    samples.samples.len() - 1
+                } else {
+                    track.inst.inst as usize
+                };
                 *buf = RenderBuffer::new(samples.samples[index].clone());
             } else {
-                let index = if idx >= samples.samples.len() {samples.samples.len() - 1} else {idx};
+                let index = if idx >= samples.samples.len() { samples.samples.len() - 1 } else { idx };
                 *buf = RenderBuffer::new(samples.samples[index].clone());
             }
         }
@@ -356,27 +361,23 @@ impl OrgPlaybackEngine {
                         let (sl1, sr1, sl2, sr2) = match (is_16bit, is_stereo) {
                             (true, true) => unsafe {
                                 let ps = pos << 2;
-                                let sl1 = (*sample_data_ptr.add(ps) as u16
-                                    | (*sample_data_ptr.add(ps + 1) as u16) << 8)
+                                let sl1 = (*sample_data_ptr.add(ps) as u16 | (*sample_data_ptr.add(ps + 1) as u16) << 8)
                                     as f32
                                     / 32768.0;
-                                let sr1 =
-                                    (*sample_data_ptr.add(ps + 2) as u16
-                                        | (*sample_data_ptr.add(ps + 3) as u16) << 8)
-                                        as f32
-                                        / 32768.0;
+                                let sr1 = (*sample_data_ptr.add(ps + 2) as u16
+                                    | (*sample_data_ptr.add(ps + 3) as u16) << 8)
+                                    as f32
+                                    / 32768.0;
                                 let ps = min(pos + 1, buf.base_pos + buf.len - 1) << 2;
-                                let sl2 = (*sample_data_ptr.add(ps) as u16
-                                    | (*sample_data_ptr.add(ps + 1) as u16) << 8)
+                                let sl2 = (*sample_data_ptr.add(ps) as u16 | (*sample_data_ptr.add(ps + 1) as u16) << 8)
                                     as f32
                                     / 32768.0;
-                                let sr2 =
-                                    (*sample_data_ptr.add(ps + 2) as u16
-                                        | (*sample_data_ptr.add(ps + 3) as u16) << 8)
-                                        as f32
-                                        / 32768.0;
+                                let sr2 = (*sample_data_ptr.add(ps + 2) as u16
+                                    | (*sample_data_ptr.add(ps + 3) as u16) << 8)
+                                    as f32
+                                    / 32768.0;
                                 (sl1, sr1, sl2, sr2)
-                            }
+                            },
                             (false, true) => unsafe {
                                 let ps = pos << 1;
                                 let sl1 = (*sample_data_ptr.add(ps) as f32 - 128.0) / 128.0;
@@ -385,26 +386,24 @@ impl OrgPlaybackEngine {
                                 let sl2 = (*sample_data_ptr.add(ps) as f32 - 128.0) / 128.0;
                                 let sr2 = (*sample_data_ptr.add(ps + 1) as f32 - 128.0) / 128.0;
                                 (sl1, sr1, sl2, sr2)
-                            }
+                            },
                             (true, false) => unsafe {
                                 let ps = pos << 1;
-                                let s1 = (*sample_data_ptr.add(ps) as u16
-                                    | (*sample_data_ptr.add(ps + 1) as u16) << 8)
+                                let s1 = (*sample_data_ptr.add(ps) as u16 | (*sample_data_ptr.add(ps + 1) as u16) << 8)
                                     as f32
                                     / 32768.0;
                                 let ps = min(pos + 1, buf.base_pos + buf.len - 1) << 1;
-                                let s2 = (*sample_data_ptr.add(ps) as u16
-                                    | (*sample_data_ptr.add(ps + 1) as u16) << 8)
+                                let s2 = (*sample_data_ptr.add(ps) as u16 | (*sample_data_ptr.add(ps + 1) as u16) << 8)
                                     as f32
                                     / 32768.0;
                                 (s1, s1, s2, s2)
-                            }
+                            },
                             (false, false) => unsafe {
                                 let s1 = (*sample_data_ptr.add(pos) as f32 - 128.0) / 128.0;
                                 let pos = min(pos + 1, buf.base_pos + buf.len - 1);
                                 let s2 = (*sample_data_ptr.add(pos) as f32 - 128.0) / 128.0;
                                 (s1, s1, s2, s2)
-                            }
+                            },
                         };
 
                         let r1 = buf.position.fract() as f32;
@@ -634,7 +633,10 @@ impl RenderBuffer {
             volume: 0,
             pan: 0,
             len: 0,
-            sample: WavSample { format: WavFormat { channels: 2, sample_rate: 22050, bit_depth: 16 }, data: vec![] },
+            sample: WavSample {
+                format: WavFormat { channels: 2, sample_rate: 22050, bit_depth: 16 },
+                data: Arc::new([]),
+            },
             playing: false,
             looping: false,
             base_pos: 0,
@@ -645,16 +647,15 @@ impl RenderBuffer {
         }
     }
 
-    pub fn new_organya(mut sample: WavSample) -> RenderBuffer {
-        let wave = sample.data.clone();
-        sample.data.clear();
+    pub fn new_organya(format: WavFormat, wave: Vec<u8>) -> RenderBuffer {
+        let mut sample_data = Vec::with_capacity(wave.len());
 
         for size in &[256_usize, 256, 128, 128, 64, 32, 16, 8] {
             let step = 256 / size;
             let mut acc = 0;
 
             for _ in 0..*size {
-                sample.data.push(wave[acc]);
+                sample_data.push(wave[acc]);
                 acc += step;
 
                 if acc >= 256 {
@@ -663,7 +664,7 @@ impl RenderBuffer {
             }
         }
 
-        RenderBuffer::new(sample)
+        RenderBuffer::new(WavSample { format, data: sample_data.into() })
     }
 
     #[inline]

--- a/src/sound/org_playback.rs
+++ b/src/sound/org_playback.rs
@@ -648,9 +648,10 @@ impl RenderBuffer {
     }
 
     pub fn new_organya(format: WavFormat, wave: Vec<u8>) -> RenderBuffer {
-        let mut sample_data = Vec::with_capacity(wave.len());
+        const SIZES: &[usize] = &[256, 256, 128, 128, 64, 32, 16, 8];
+        let mut sample_data = Vec::with_capacity(SIZES.iter().sum());
 
-        for size in &[256_usize, 256, 128, 128, 64, 32, 16, 8] {
+        for size in SIZES {
             let step = 256 / size;
             let mut acc = 0;
 

--- a/src/sound/wav.rs
+++ b/src/sound/wav.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 use std::io;
 use std::io::ErrorKind;
+use std::sync::Arc;
 
-use byteorder::{LE, ReadBytesExt};
+use byteorder::{ReadBytesExt, LE};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct RiffChunk {
@@ -42,7 +43,7 @@ impl fmt::Display for WavFormat {
 #[derive(Clone)]
 pub struct WavSample {
     pub format: WavFormat,
-    pub data: Vec<u8>,
+    pub data: Arc<[u8]>,
 }
 
 impl fmt::Display for WavSample {
@@ -116,6 +117,6 @@ impl WavSample {
 
         f.read_exact(&mut buf)?;
 
-        Ok(WavSample { format: WavFormat { channels, sample_rate: samples, bit_depth: bits }, data: buf })
+        Ok(WavSample { format: WavFormat { channels, sample_rate: samples, bit_depth: bits }, data: buf.into() })
     }
 }

--- a/src/sound/wave_bank.rs
+++ b/src/sound/wave_bank.rs
@@ -1,20 +1,21 @@
 use std::fmt;
 use std::io;
+use std::sync::Arc;
 
 use crate::sound::wav;
 
 #[derive(Clone)]
 pub struct SoundBank {
-    pub wave100: Box<[u8; 25600]>,
+    pub wave100: Arc<[u8; 25600]>,
 
-    pub samples: Vec<wav::WavSample>,
+    pub samples: Arc<[wav::WavSample]>,
 }
 
 impl fmt::Display for SoundBank {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "WAVE100: {:2X?}...", &self.wave100[..8])?;
 
-        for sample in &self.samples {
+        for sample in self.samples.iter() {
             writeln!(f, "{}", sample)?;
         }
 
@@ -38,7 +39,7 @@ impl SoundBank {
                 }
                 Err(err) => {
                     log::error!("Failed to read next sample: {}", err);
-                    return Ok(SoundBank { wave100, samples });
+                    return Ok(SoundBank { wave100: wave100.into(), samples: samples.into() });
                 }
             }
         }


### PR DESCRIPTION
Hi there! This PR aims to better reuse sound buffers, to achieve (very slightly) less memory usage and such

Where I think this would be especially useful is in `play_song`, which clones `RenderBuffer` 16 times. Now, those would practically be a `Copy` operation. Same applies to the `SoundBank` struct itself, which is cloned in a few places.

Not the most scientific test in the world, but these are roughly the results I got:

## Before

![telegram-cloud-photo-size-1-5071267577052901215-y](https://github.com/user-attachments/assets/ea3b6fbb-0df1-47a8-80f4-3a357b3f093c)

## After

![telegram-cloud-photo-size-1-5071267577052901218-y](https://github.com/user-attachments/assets/3dda1d45-ff3b-449a-9938-cafd9f92b621)

I don't know how reliable or reproducible these results are. Those are in macOS, and in the debug build