### PR TITLE
Fix SW rendering on SDL2

### DIFF
--- a/src/framework/backend_sdl2.rs
+++ b/src/framework/backend_sdl2.rs
@@ -128,8 +128,6 @@ impl WindowOrCanvas {
         if let WindowOrCanvas::Win(window) = self {
             let canvas = window
                 .into_canvas()
-                .accelerated()
-                .present_vsync()
                 .build()
                 .map_err(|e| GameError::RenderError(e.to_string()))?;
 
@@ -489,7 +487,9 @@ impl BackendEventLoop for SDL2EventLoop {
                 GLContext { gles2_mode: false, is_sdl: true, get_proc_address, swap_buffers, user_data, ctx };
 
             return Ok(Box::new(OpenGLRenderer::new(gl_context, UnsafeCell::new(imgui))));
-        } else {
+        }
+        
+        {
             let mut refs = self.refs.borrow_mut();
             let window = std::mem::take(&mut refs.window);
             refs.window = window.make_canvas()?;


### PR DESCRIPTION
Unconditionally creates canvas (that is later asserted to exist) in SW rendering path of SDL2 renderer creation.

The code presumably assumed the if branch that is #[cfg]-ed would leave the else branch standing if the cfg is false, but it does not. This leads to the fact that WindowOrCanvas class remains in Window mode, later hitting UB at https://github.com/doukutsu-rs/doukutsu-rs/blob/1ba5f58/src/framework/backend_sdl2.rs#L122. 
Since the if branch is diverging, we can just leave the else branch as-is.

It also removes the requirements of HW accelerated and vsync capable backend from SDL. I think the code wanted to show a preference for renderers with this capability, but looking at SDL code, it [acts as hard filter](https://github.com/libsdl-org/SDL/blob/07d0f51fa292895443f563f0cbde4cb3802d87fa/src/render/SDL_render.c#L1012) (version is based on what's bundled in sdl2-sys). As the backends are tried in [order from most to least powerful](https://github.com/libsdl-org/SDL/blob/main/src/render/SDL_render.c#L110), I don't think that adds anything and decreases portability unnecessarily.

Note that removal of vsync specifically is not strictly needed and is more of a theoretical compatibility benefit - SW renderer does support it and I haven't checked if removal of that flag makes renderers not attempt to turn the vsync on at all, which would be a regression. Maybe there's some other api for turning vsync on where available?

With these changes I was able to build this project on top of WSL2 with X11 and no OpenGL as a proof of concept.
As a side note, there was no audio, but cpal is [about to get PulseAudio support](https://github.com/RustAudio/cpal/pull/957) and with [this fix](https://github.com/colinmarc/pulseaudio-rs/pull/4) I was able to get it working too, although the extreme latencies made _the audio part_ not practical. Furthermore, this codebase currently doesn't support multiple audio hosts (`let host = cpal::default_host();`), which would need to be made more flexible as default Linux host is ALSA, not PulseAudio, which doesn't support remotes.

Tested build with `cargo run --no-default-features --features default-base,backend-sdl,exe,webbrowser`.